### PR TITLE
Feature/itm 332 error handling

### DIFF
--- a/backend/Application.UnitTests/ActionApprovers/Commands/CreateActionApprovers/CreateActionApproversCommandTest.cs
+++ b/backend/Application.UnitTests/ActionApprovers/Commands/CreateActionApprovers/CreateActionApproversCommandTest.cs
@@ -97,7 +97,7 @@ namespace Application.UnitTests.ActionApprovers.Commands.CreateActionApprovers
     {
       var command = new CreateActionApproverCommand
       {
-        Id = 99,
+        Id = 1,
         ActionApprovers = new List<ActionApproverDto>{
           new ActionApproverDto
           {
@@ -113,7 +113,7 @@ namespace Application.UnitTests.ActionApprovers.Commands.CreateActionApprovers
 
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
   }
 }

--- a/backend/Application.UnitTests/ActionApprovers/Queries/GetActionApproversByActionIdQueryTest.cs
+++ b/backend/Application.UnitTests/ActionApprovers/Queries/GetActionApproversByActionIdQueryTest.cs
@@ -54,7 +54,7 @@ namespace Application.UnitTests.ActionApprovers.Queries
 
       var handler = new GetActionApproversByActionIdQuery.GetActionApproversByActionIdQueryHandler(_context, _mapper, _invalidUserService);
       Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
   }
 }

--- a/backend/Application.UnitTests/ActionApprovers/Queries/GetActionApproversByServiceIdQueryTest.cs
+++ b/backend/Application.UnitTests/ActionApprovers/Queries/GetActionApproversByServiceIdQueryTest.cs
@@ -56,7 +56,7 @@ namespace Application.UnitTests.ActionApprovers.Queries
       var handler = new GetActionApproversByServiceIdQuery.GetActionApproversByServiceIdQueryHandler(_context, _mapper, _invalidUserService);
 
       Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
   }
 }

--- a/backend/Application.UnitTests/Actions/Commands/CreateAction/CreateActionCommandTest.cs
+++ b/backend/Application.UnitTests/Actions/Commands/CreateAction/CreateActionCommandTest.cs
@@ -65,7 +65,7 @@ namespace Application.UnitTests.Actions.Commands.CreateAction
     {
       var command = new CreateActionCommand()
       {
-        Id = 99,
+        Id = 1,
         Action = new ActionDto()
         {
           Title = "Test of createAction",
@@ -78,7 +78,7 @@ namespace Application.UnitTests.Actions.Commands.CreateAction
 
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
     [Fact]
     public void Handle_DuplicateIdentifier_ShouldThrowError()

--- a/backend/Application.UnitTests/Actions/Commands/CreateAction/CreateActionCommandTest.cs
+++ b/backend/Application.UnitTests/Actions/Commands/CreateAction/CreateActionCommandTest.cs
@@ -97,7 +97,7 @@ namespace Application.UnitTests.Actions.Commands.CreateAction
       var handler = new CreateActionCommand.CreateActionCommandHandler(Context, CurrentUserServiceMock.Object);
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<DuplicateIdentifierException>();
     }
   }
 }

--- a/backend/Application.UnitTests/AppTokenActions/Commands/CreateAppTokenAction/CreateAppTokenActionCommandTest.cs
+++ b/backend/Application.UnitTests/AppTokenActions/Commands/CreateAppTokenAction/CreateAppTokenActionCommandTest.cs
@@ -107,7 +107,7 @@ namespace Application.UnitTests.AppTokenActions.Commands.CreateAppTokenAction
       var handler = new CreateAppTokenActionsCommand.CreateAppTokenActionsCommandHandler(Context, InvalidUserServiceMock.Object);
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
 
   }

--- a/backend/Application.UnitTests/AppTokens/Commands/CreateAppToken/CreateAppTokenCommandTest.cs
+++ b/backend/Application.UnitTests/AppTokens/Commands/CreateAppToken/CreateAppTokenCommandTest.cs
@@ -73,7 +73,7 @@ namespace Application.UnitTests.AppTokens.Commands.CreateAppToken
 
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
     [Fact]
     public void Handle_DuplicateIdentifier_ShouldThrowError()

--- a/backend/Application.UnitTests/AppTokens/Commands/CreateAppToken/CreateAppTokenCommandTest.cs
+++ b/backend/Application.UnitTests/AppTokens/Commands/CreateAppToken/CreateAppTokenCommandTest.cs
@@ -91,7 +91,7 @@ namespace Application.UnitTests.AppTokens.Commands.CreateAppToken
       var handler = new CreateAppTokenCommand.CreateAppTokenCommandHandler(Context, CurrentUserServiceMock.Object);
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<DuplicateIdentifierException>();
     }
   }
 }

--- a/backend/Application.UnitTests/AppTokens/Commands/UpdateAppTokenActions/UpdateAppTokenStateCommandTest.cs
+++ b/backend/Application.UnitTests/AppTokens/Commands/UpdateAppTokenActions/UpdateAppTokenStateCommandTest.cs
@@ -43,7 +43,7 @@ namespace Application.UnitTests.AppTokens.Commands.UpdateAppTokenActions
       var handler = new UpdateAppTokenStateCommand.UpdateAppTokenStateCommandHandler(Context, InvalidUserServiceMock.Object);
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
     [Fact]
     public void Handle_InvalidTokenId_ShouldThrowError()

--- a/backend/Application.UnitTests/AppTokens/Queries/GetAppTokensByAppIdQueryTest.cs
+++ b/backend/Application.UnitTests/AppTokens/Queries/GetAppTokensByAppIdQueryTest.cs
@@ -60,7 +60,7 @@ namespace Application.UnitTests.AppTokens.Queries
 
       Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
   }
 }

--- a/backend/Application.UnitTests/ApplicationOwners/Commands/CreateApplicationOwners/CreateApplicationOwnerCommandTest.cs
+++ b/backend/Application.UnitTests/ApplicationOwners/Commands/CreateApplicationOwners/CreateApplicationOwnerCommandTest.cs
@@ -100,7 +100,7 @@ namespace Application.UnitTests.ApplicationOwners.Commands.CreateApplicationOwne
     {
       var command = new CreateApplicationOwnerCommand
       {
-        Id = 99,
+        Id = 1,
         AppOwners = new List<ApplicationOwnerDto>{
           new ApplicationOwnerDto
           {
@@ -116,7 +116,7 @@ namespace Application.UnitTests.ApplicationOwners.Commands.CreateApplicationOwne
 
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
   }
 }

--- a/backend/Application.UnitTests/ApplicationOwners/Queries/GetAppOwnersByAppIdQueryTest.cs
+++ b/backend/Application.UnitTests/ApplicationOwners/Queries/GetAppOwnersByAppIdQueryTest.cs
@@ -54,7 +54,7 @@ namespace Application.UnitTests.ApplicationOwners.Queries
 
       Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
   }
 }

--- a/backend/Application.UnitTests/Applications/Commands/CreateApplication/CreateApplicationCommandTest.cs
+++ b/backend/Application.UnitTests/Applications/Commands/CreateApplication/CreateApplicationCommandTest.cs
@@ -52,7 +52,7 @@ namespace Application.UnitTests.Applications.Commands.CreateApplication
       var handler = new CreateApplicationCommand.CreateApplicationCommandHandler(Context, AuthCient, CurrentUserServiceMock.Object);
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<DuplicateIdentifierException>();
     }
   }
 }

--- a/backend/Application.UnitTests/Applications/Commands/UpdateApplication/UpdateApplicationCommandTest.cs
+++ b/backend/Application.UnitTests/Applications/Commands/UpdateApplication/UpdateApplicationCommandTest.cs
@@ -71,7 +71,7 @@ namespace Application.UnitTests.Applications.Commands.UpdateApplication
 
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
   }
 }

--- a/backend/Application.UnitTests/Applications/Queries/GetApplications/GetApplicationsQueryTest.cs
+++ b/backend/Application.UnitTests/Applications/Queries/GetApplications/GetApplicationsQueryTest.cs
@@ -46,15 +46,16 @@ namespace Application.UnitTests.Applications.Queries.GetApplications
       result.Count.Should().Be(2); // The test user currenlty owns 2 out of 3 Applications
     }
     [Fact]
-    public void Handle_InvalidUser_ShouldThrowError()
+    public async Task Handle_InvalidUser_ShouldReturnEmptyArray()
     {
       var query = new GetMyApplicationsQuery();
 
       var handler = new GetMyApplicationsQuery.GetMyApplicationQueryHandler(_context, _mapper, _invalidUserService);
 
-      Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
+      var result = await handler.Handle(query, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      result.Should().BeOfType<List<ApplicationIdDto>>();
+      result.Count.Should().Be(0); // The invalid user just receives empty array since he owns no applications
     }
   }
 }

--- a/backend/Application.UnitTests/Applications/Queries/GetApplications/GetMyAppOverviewQueryTest.cs
+++ b/backend/Application.UnitTests/Applications/Queries/GetApplications/GetMyAppOverviewQueryTest.cs
@@ -46,15 +46,16 @@ namespace Application.UnitTests.Applications.Queries.GetApplications
       result.Count.Should().Be(2); // The test user currenlty owns 2 out of 3 Applications
     }
     [Fact]
-    public void Handle_InvalidUser_ShouldThrowError()
+    public async Task Handle_InvalidUser_ShouldReturnEmptyArray()
     {
       var query = new GetMyAppOverviewQuery();
 
       var handler = new GetMyAppOverviewQuery.GetMyAppOverviewQueryHandler(_context, _mapper, _invalidUserService);
 
-      Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
+      var result = await handler.Handle(query, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      result.Should().BeOfType<List<AppOverviewDto>>();
+      result.Count.Should().Be(0); // invalidUser owns no applications
     }
   }
 }

--- a/backend/Application.UnitTests/ServiceOwners/Commands/CreateServiceOwnersCommand/CreateServiceOwnersCommandTest.cs
+++ b/backend/Application.UnitTests/ServiceOwners/Commands/CreateServiceOwnersCommand/CreateServiceOwnersCommandTest.cs
@@ -100,7 +100,7 @@ namespace Application.UnitTests.ServiceOwners.Commands.CreateServiceOwnersComman
     {
       var command = new CreateServiceOwnerCommand
       {
-        Id = 99,
+        Id = 1,
         ServiceOwners = new List<ServiceOwnerDto>{
           new ServiceOwnerDto
           {
@@ -116,7 +116,7 @@ namespace Application.UnitTests.ServiceOwners.Commands.CreateServiceOwnersComman
 
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
   }
 }

--- a/backend/Application.UnitTests/ServiceOwners/Queries/GetServiceOwnersByServiceIdQueryTest.cs
+++ b/backend/Application.UnitTests/ServiceOwners/Queries/GetServiceOwnersByServiceIdQueryTest.cs
@@ -56,7 +56,7 @@ namespace Application.UnitTests.ServiceOwners.Queries
 
       Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
     }
   }
 }

--- a/backend/Application.UnitTests/Services/Commands/CreateService/CreateServiceCommandTest.cs
+++ b/backend/Application.UnitTests/Services/Commands/CreateService/CreateServiceCommandTest.cs
@@ -49,7 +49,7 @@ namespace Application.UnitTests.Services.Commands.CreateService
       var handler = new CreateServiceCommand.CreateServiceCommandHandler(Context, CurrentUserServiceMock.Object);
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<DuplicateIdentifierException>();
     }
   }
 }

--- a/backend/Application.UnitTests/Services/Queries/GetService/GetServiceByIdQueryTest.cs
+++ b/backend/Application.UnitTests/Services/Queries/GetService/GetServiceByIdQueryTest.cs
@@ -68,7 +68,7 @@ namespace Application.UnitTests.Services.Queries.GetService
       var handler = new GetServiceByIdQuery.GetServiceByIdQueryHandler(_context, _mapper, _invalidUserService);
       Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      action.Should().Throw<ForbiddenAccessException>();
 
     }
   }

--- a/backend/Application.UnitTests/Services/Queries/GetServices/GetMyServicesOverviewQueryTest.cs
+++ b/backend/Application.UnitTests/Services/Queries/GetServices/GetMyServicesOverviewQueryTest.cs
@@ -46,15 +46,16 @@ namespace Application.UnitTests.Services.Queries.GetServices
     }
 
     [Fact]
-    public void Handle_InvalidUser_ShouldThrowError()
+    public async Task Handle_InvalidUser_ShouldThrowError()
     {
       var query = new GetMyServicesOverviewQuery();
 
       var handler = new GetMyServicesOverviewQuery.GetMyServicesOverviewQueryHandler(_context, _mapper, _invalidUserService);
 
-      Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
+      var result = await handler.Handle(query, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      result.Should().BeOfType<List<ServiceOverviewDto>>();
+      result.Count.Should().Be(0); // Invalid user owns no services so should return empty array but not throw error
     }
   }
 }

--- a/backend/Application.UnitTests/Services/Queries/GetServices/GetMyServicesQueryTest.cs
+++ b/backend/Application.UnitTests/Services/Queries/GetServices/GetMyServicesQueryTest.cs
@@ -48,15 +48,16 @@ namespace Application.UnitTests.Services.Queries.GetServices
 
     }
     [Fact]
-    public void Handle_InvalidUser_ShouldThrowError()
+    public async Task Handle_InvalidUser_ShouldReturnEmptyArray()
     {
       var query = new GetMyServicesQuery();
 
       var handler = new GetMyServicesQuery.GetMyServicesQueryHandler(_context, _mapper, _invalidUserService);
 
-      Func<Task> action = async () => await handler.Handle(query, CancellationToken.None);
+      var result = await handler.Handle(query, CancellationToken.None);
 
-      action.Should().Throw<NotFoundException>();
+      result.Should().BeOfType<List<ServiceIdDto>>();
+      result.Count.Should().Be(0); // Invalid user owns no services so should return empty array but not throw error
     }
   }
 }

--- a/backend/Application/ActionApprovers/Commands/CreateActionApprovers/CreateActionApproverCommand.cs
+++ b/backend/Application/ActionApprovers/Commands/CreateActionApprovers/CreateActionApproverCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -9,6 +10,7 @@ using Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
+using Action = Domain.Entities.Action;
 
 namespace Application.ActionApprovers.Commands.CreateActionApprovers
 {
@@ -38,7 +40,7 @@ namespace Application.ActionApprovers.Commands.CreateActionApprovers
         }
         if (!await _context.ActionApprovers.AnyAsync(e => e.ActionId == request.Id && e.Email == _currentUserService.UserEmail, cancellationToken))
         {
-          throw new NotFoundException(nameof(Action), request.Id + "Not authorized for the given Action");
+          throw new ForbiddenAccessException(nameof(Action), key: request.Id);
         }
         var existingApprovers = _context.ActionApprovers.Where(e => e.ActionId == request.Id);
         var newApprovers = request.ActionApprovers

--- a/backend/Application/ActionApprovers/Queries/GetActionApproversByActionId/GetActionApproversByActionIdQuery.cs
+++ b/backend/Application/ActionApprovers/Queries/GetActionApproversByActionId/GetActionApproversByActionIdQuery.cs
@@ -36,7 +36,7 @@ namespace Application.ActionApprovers.Queries.GetActionApproversByActionId
         var owners = _context.ActionApprovers.Where(e => e.ActionId == request.Id);
         if (!owners.Any(e => e.Email == _currentUserService.UserEmail))
         {
-          throw new NotFoundException(nameof(ActionApprover), "You don't have permission for action:" + request.Id);
+          throw new ForbiddenAccessException(nameof(Action), key: request.Id);
         }
         var result = await owners.ProjectTo<ActionApproverIdDto>(_mapper.ConfigurationProvider)
           .ToListAsync(cancellationToken);

--- a/backend/Application/ActionApprovers/Queries/GetActionApproversByServiceId/GetActionApproversByServiceIdQuery.cs
+++ b/backend/Application/ActionApprovers/Queries/GetActionApproversByServiceId/GetActionApproversByServiceIdQuery.cs
@@ -34,8 +34,9 @@ namespace Application.ActionApprovers.Queries.GetActionApproversByServiceId
         var owners = _context.ActionApprovers.Where(e => actions.Any(x => x.Id == e.ActionId));
         if (!owners.Any(e => e.Email == _currentUserService.UserEmail))
         {
-          throw new NotFoundException(nameof(ActionApprover), "You don't have permission for action:" + request.Id);
+          throw new ForbiddenAccessException(nameof(Service), key: request.Id);
         }
+
         var result = await owners.ProjectTo<ActionApproverIdDto>(_mapper.ConfigurationProvider)
           .ToListAsync(cancellationToken);
         return result;

--- a/backend/Application/Actions/Commands/CreateAction/CreateActionCommand.cs
+++ b/backend/Application/Actions/Commands/CreateAction/CreateActionCommand.cs
@@ -42,7 +42,7 @@ namespace Application.Actions.Commands.CreateAction
         if (!await _context.ServiceOwners.AnyAsync(
           e => e.ServiceId == request.Id && e.Email == _currentUserService.UserEmail, cancellationToken))
         {
-          throw new NotFoundException(nameof(Service), request.Id+"Not authorized");
+          throw new ForbiddenAccessException(nameof(Service), key: request.Id);
         }
         if (await _context.Actions.AnyAsync(e => e.ActionIdentifier == request.Action.ActionIdentifier && e.ServiceId == request.Id, cancellationToken))
         {

--- a/backend/Application/Actions/Commands/CreateAction/CreateActionCommand.cs
+++ b/backend/Application/Actions/Commands/CreateAction/CreateActionCommand.cs
@@ -46,9 +46,9 @@ namespace Application.Actions.Commands.CreateAction
         }
         if (await _context.Actions.AnyAsync(e => e.ActionIdentifier == request.Action.ActionIdentifier && e.ServiceId == request.Id, cancellationToken))
         {
-          throw new NotFoundException(nameof(Domain.Entities.AppToken),
-            key: request.Id + "A Action with that identifier already exists");
+          throw new DuplicateIdentifierException(nameof(Domain.Entities.Action), key: request.Action.ActionIdentifier);
         }
+
 
         var action = new Action
         {

--- a/backend/Application/AppTokenActions/Commands/CreateAppTokenAction/CreateAppTokenActionCommand.cs
+++ b/backend/Application/AppTokenActions/Commands/CreateAppTokenAction/CreateAppTokenActionCommand.cs
@@ -41,7 +41,7 @@ namespace Application.AppTokenActions.Commands.CreateAppTokenAction
         }
         if (!_context.AppOwners.Any(e => e.ApplicationId == token.ApplicationId && e.Email == _currentUserService.UserEmail))
         {
-          throw new NotFoundException(nameof(Domain.Entities.AppToken), request.TokenId + "Not authorized for the given Token");
+          throw new ForbiddenAccessException(nameof(Domain.Entities.AppToken), request.TokenId);
         }
 
         var serviceActions = _context.Actions;

--- a/backend/Application/AppTokens/Commands/CreateAppToken/CreateAppTokenCommand.cs
+++ b/backend/Application/AppTokens/Commands/CreateAppToken/CreateAppTokenCommand.cs
@@ -39,8 +39,8 @@ namespace Application.AppTokens.Commands.CreateAppToken
         }
         if (await _context.AppTokens.AnyAsync(e => e.TokenIdentifier == request.AppToken.TokenIdentifier && e.ApplicationId == request.Id, cancellationToken))
         {
-          throw new NotFoundException(nameof(Domain.Entities.AppToken),
-            key: request.Id + "A Token with that identifier already exists");
+          throw new DuplicateIdentifierException(nameof(Domain.Entities.AppToken),
+            key: request.AppToken.TokenIdentifier);
         }
         
         var appToken = new AppToken()

--- a/backend/Application/AppTokens/Commands/CreateAppToken/CreateAppTokenCommand.cs
+++ b/backend/Application/AppTokens/Commands/CreateAppToken/CreateAppTokenCommand.cs
@@ -35,7 +35,7 @@ namespace Application.AppTokens.Commands.CreateAppToken
         if (!await _context.Applications.AnyAsync(e => e.Id == request.Id, cancellationToken)) throw new NotFoundException(nameof(ApplicationEntity), request.Id);
         if (!await _context.AppOwners.AnyAsync(e => e.ApplicationId == request.Id && e.Email == _currentUserService.UserEmail, cancellationToken))
         {
-          throw new NotFoundException(nameof(ApplicationEntity), request.Id + "Not authorized for the given Application");
+          throw new ForbiddenAccessException(nameof(ApplicationEntity), request.Id);
         }
         if (await _context.AppTokens.AnyAsync(e => e.TokenIdentifier == request.AppToken.TokenIdentifier && e.ApplicationId == request.Id, cancellationToken))
         {

--- a/backend/Application/AppTokens/Commands/UpdateAppTokenState/UpdateAppTokenStateCommand.cs
+++ b/backend/Application/AppTokens/Commands/UpdateAppTokenState/UpdateAppTokenStateCommand.cs
@@ -36,7 +36,7 @@ namespace Application.AppTokens.Commands.UpdateAppTokenActions
         if (appToken == null) throw new NotFoundException(nameof(Domain.Entities.AppToken), request.Id);
         if (!_context.AppOwners.Any(e => e.ApplicationId == appToken.ApplicationId && e.Email == _currentUserService.UserEmail))
         {
-          throw new NotFoundException(nameof(ApplicationEntity), request.Id + "Not authorized for the given Application");
+          throw new ForbiddenAccessException(nameof(ApplicationEntity), request.Id);
         }
         appToken.State = request.NewState;
         _context.AppTokens.Update(appToken);

--- a/backend/Application/ApplicationOwners/Commands/CreateApplicationOwners/CreateApplicationOwnerCommand.cs
+++ b/backend/Application/ApplicationOwners/Commands/CreateApplicationOwners/CreateApplicationOwnerCommand.cs
@@ -38,7 +38,7 @@ namespace Application.ApplicationOwners.Commands.CreateApplicationOwners
         }
         if (!await _context.AppOwners.AnyAsync(e => e.ApplicationId == request.Id && e.Email == _currentUserService.UserEmail, cancellationToken))
         {
-          throw new NotFoundException(nameof(ApplicationEntity), request.Id + "Not authorized for the given Application");
+          throw new ForbiddenAccessException(nameof(ApplicationEntity), key: request.Id);
         }
         var existingOwners = _context.AppOwners.Where(e => e.ApplicationId == request.Id);
         var newOwners =request.AppOwners

--- a/backend/Application/ApplicationOwners/Queries/GetAppOwnersByAppId/GetAppOwnersByAppIdQuery.cs
+++ b/backend/Application/ApplicationOwners/Queries/GetAppOwnersByAppId/GetAppOwnersByAppIdQuery.cs
@@ -37,7 +37,7 @@ namespace Application.ApplicationOwners.Queries.GetAppOwnersByAppId
         var owners = _context.AppOwners.Where(e => e.ApplicationId == request.Id);
         if (!owners.Any(e => e.Email == _currentUserService.UserEmail))
         {
-          throw new NotFoundException(nameof(ApplicationOwner), "You don't have permission for application:" +request.Id);
+          throw new ForbiddenAccessException(nameof(ApplicationEntity), key: request.Id);
         }
         var result = await owners.ProjectTo<ApplicationOwnerIdDto>(_mapper.ConfigurationProvider)
           .ToListAsync(cancellationToken);

--- a/backend/Application/Applications/Commands/CreateApplication/CreateApplicationCommand.cs
+++ b/backend/Application/Applications/Commands/CreateApplication/CreateApplicationCommand.cs
@@ -36,8 +36,7 @@ namespace Application.Applications.Commands.CreateApplication
       {
         if (await _context.Applications.AnyAsync(e => e.AppIdentifier == request.Application.AppIdentifier, cancellationToken))
         {
-          throw new NotFoundException(nameof(ApplicationEntity),
-            key: request.Application.AppIdentifier + "A App with that identifier already exists");
+          throw new DuplicateIdentifierException(nameof(ApplicationEntity), key: request.Application.AppIdentifier);
         }
         var application = new ApplicationEntity
         {

--- a/backend/Application/Applications/Commands/UpdateApplication/UpdateApplicationCommand.cs
+++ b/backend/Application/Applications/Commands/UpdateApplication/UpdateApplicationCommand.cs
@@ -34,14 +34,16 @@ namespace Application.Applications.Commands.UpdateApplication
 
       public async Task<Unit> Handle(UpdateApplicationCommand request, CancellationToken cancellationToken)
       {
-        if (!await _context.AppOwners.AnyAsync(e => e.ApplicationId == request.Id && e.Email == _currentUserService.UserEmail, cancellationToken))
-        {
-          throw new NotFoundException(nameof(ApplicationOwner), request.Id);
 
-        }
         var application = await _context.Applications.FindAsync(request.Id);
 
         if (application == null) throw new NotFoundException(nameof(ApplicationEntity), request.Id);
+
+        if (!await _context.AppOwners.AnyAsync(e => e.ApplicationId == request.Id && e.Email == _currentUserService.UserEmail, cancellationToken))
+        {
+          throw new ForbiddenAccessException(nameof(ApplicationEntity), request.Id);
+
+        }
 
         application.Title = request.Application.Title;
         application.Description = request.Application.Description;

--- a/backend/Application/Applications/Queries/GetApplications/GetMyAppOverviewQuery.cs
+++ b/backend/Application/Applications/Queries/GetApplications/GetMyAppOverviewQuery.cs
@@ -32,7 +32,6 @@ namespace Application.Applications.Queries.GetApplications
       {
         var ownedApps = _context.AppOwners.Where(e => e.Email == _currentUserService.UserEmail)
           .Select(e => e.ApplicationId).ToList();
-        if (!ownedApps.Any()) throw new NotFoundException(nameof(ApplicationOwner), "You have no application" + _currentUserService.UserEmail);
 
         var applications = await _context.Applications
           .Where(e => ownedApps.Contains(e.Id))

--- a/backend/Application/Applications/Queries/GetApplications/GetMyApplicationsQuery.cs
+++ b/backend/Application/Applications/Queries/GetApplications/GetMyApplicationsQuery.cs
@@ -39,7 +39,6 @@ namespace Application.Applications.Queries.GetApplications
       {
         var ownedApps = _context.AppOwners.Where(e => e.Email == _currentUserService.UserEmail)
           .Select(e => e.ApplicationId).ToList();
-        if (!ownedApps.Any()) throw new NotFoundException(nameof(ApplicationOwner), "You have no application" + _currentUserService.UserEmail);
 
         var applications = await _context.Applications
           .Where(e => ownedApps.Contains(e.Id))

--- a/backend/Application/Common/Exceptions/DuplicateIdentiferException.cs
+++ b/backend/Application/Common/Exceptions/DuplicateIdentiferException.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Application.Common.Exceptions
+{
+  public class DuplicateIdentifierException : Exception
+  {
+    public DuplicateIdentifierException()
+      : base()
+    {
+    }
+
+    public DuplicateIdentifierException(string message)
+      : base(message)
+    {
+    }
+
+    public DuplicateIdentifierException(string message, Exception innerException)
+      : base(message, innerException)
+    {
+    }
+
+    public DuplicateIdentifierException(string name, object key)
+      : base($"Entity \"{name}\" ({key}) is not a unique identifier")
+    {
+    }
+  }
+}

--- a/backend/Application/Common/Exceptions/ForbiddenAccessException.cs
+++ b/backend/Application/Common/Exceptions/ForbiddenAccessException.cs
@@ -8,5 +8,9 @@ namespace Application.Common.Exceptions
         : base()
     {
     }
+    public ForbiddenAccessException(string name, object key)
+      : base($"Entity \"{name}\" ({key}) you are not authorized for the given {name}")
+    {
+    }
   }
 }

--- a/backend/Application/ServiceOwners/Commands/CreateServiceOwners/CreateServiceOwnerCommand.cs
+++ b/backend/Application/ServiceOwners/Commands/CreateServiceOwners/CreateServiceOwnerCommand.cs
@@ -39,7 +39,7 @@ namespace Application.ServiceOwners.Commands.CreateServiceOwners
         }
         if (!await _context.ServiceOwners.AnyAsync(e => e.ServiceId == request.Id && e.Email == _currentUserService.UserEmail, cancellationToken))
         {
-          throw new NotFoundException(nameof(ApplicationEntity), request.Id + "Not authorized for the given Application");
+          throw new ForbiddenAccessException(nameof(ApplicationEntity), request.Id);
         }
 
         var existingOwners = _context.ServiceOwners.Where(e => e.ServiceId == request.Id);

--- a/backend/Application/ServiceOwners/Queries/GetServiceOwnersByServiceId/GetServiceOwnersByServiceIdQuery.cs
+++ b/backend/Application/ServiceOwners/Queries/GetServiceOwnersByServiceId/GetServiceOwnersByServiceIdQuery.cs
@@ -36,7 +36,7 @@ namespace Application.ServiceOwners.Queries.GetServiceOwnersByServiceId
         var owners = _context.ServiceOwners.Where(e => e.ServiceId == request.Id);
         if (!owners.Any(e => e.Email == _currentUserService.UserEmail))
         {
-          throw new NotFoundException(nameof(ServiceOwner), "You don't have permission for Service:" + request.Id);
+          throw new ForbiddenAccessException(nameof(ServiceOwner), request.Id);
         }
         var result = await owners.ProjectTo<ServiceOwnerIdDto>(_mapper.ConfigurationProvider)
           .ToListAsync(cancellationToken);

--- a/backend/Application/Services/Commands/CreateService/CreateServiceCommand.cs
+++ b/backend/Application/Services/Commands/CreateService/CreateServiceCommand.cs
@@ -36,7 +36,7 @@ namespace Application.Services.Commands.CreateService
       {
         if (await _context.Services.AnyAsync(e => e.ServiceIdentifier == request.Service.ServiceIdentifier, cancellationToken))
         {
-          throw new NotFoundException(nameof(Domain.Entities.Service), key: request.Service.ServiceIdentifier + "A Service with that identifier already exists");
+          throw new DuplicateIdentifierException(nameof(Domain.Entities.Service), key: request.Service.ServiceIdentifier);
         }
         var service = new Service
         {

--- a/backend/Application/Services/Queries/GetService/GetServiceByIdQuery.cs
+++ b/backend/Application/Services/Queries/GetService/GetServiceByIdQuery.cs
@@ -35,11 +35,6 @@ namespace Application.Services.Queries
 
       public async Task<ServiceIdDto> Handle(GetServiceByIdQuery request, CancellationToken cancellationToken)
       {
-        if (!_context.ServiceOwners.Any(e => e.Email == _currentUserService.UserEmail && e.ServiceId == request.Id))
-        {
-          throw new NotFoundException(nameof(ServiceOwner), "You don't own the requested service");
-        }
-
         var service = await _context.Services
           .Where(e => e.Id == request.Id)
           .Include(e => e.Actions)
@@ -49,7 +44,11 @@ namespace Application.Services.Queries
         {
           throw new NotFoundException(nameof(service), request.Id);
         }
-        
+        if (!_context.ServiceOwners.Any(e => e.Email == _currentUserService.UserEmail && e.ServiceId == request.Id))
+        {
+          throw new ForbiddenAccessException(nameof(ServiceOwner), request.Id);
+        }
+
         return service;
       }
     }

--- a/backend/Application/Services/Queries/GetServices/GetMyServicesOverviewQuery.cs
+++ b/backend/Application/Services/Queries/GetServices/GetMyServicesOverviewQuery.cs
@@ -32,7 +32,6 @@ namespace Application.Services.Queries.GetServices
         var ownedServices = _context.ServiceOwners
           .Where(e => e.Email == _currentUserService.UserEmail)
           .Select(e => e.ServiceId);
-        if (!ownedServices.Any()) throw new NotFoundException(nameof(ServiceOwner), "You have no services");
 
         var services = await _context.Services
           .Where(e => ownedServices.Contains(e.Id))

--- a/backend/Application/Services/Queries/GetServices/GetMyServicesQuery.cs
+++ b/backend/Application/Services/Queries/GetServices/GetMyServicesQuery.cs
@@ -37,7 +37,6 @@ namespace Application.Services.Queries.GetServices
         var ownedServices = _context.ServiceOwners
           .Where(e => e.Email == _currentUserService.UserEmail)
           .Select(e => e.ServiceId);
-        if (!ownedServices.Any()) throw new NotFoundException(nameof(ServiceOwner), "You have no services");
 
         var services = await _context.Services
           .Where(e => ownedServices.Contains(e.Id))

--- a/backend/Web/Filters/ApiExceptionFilterAttribute.cs
+++ b/backend/Web/Filters/ApiExceptionFilterAttribute.cs
@@ -93,6 +93,21 @@ namespace Web.Filters
 
       context.ExceptionHandled = true;
     }
+    private void HandleDuplicateIdentifierException(ExceptionContext context)
+    {
+      var exception = context.Exception as DuplicateIdentifierException;
+
+      var details = new ProblemDetails()
+      {
+        Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+        Title = "Duplicate Identifier",
+        Detail = exception.Message
+      };
+
+      context.Result = new NotFoundObjectResult(details);
+
+      context.ExceptionHandled = true;
+    }
 
     private void HandleUnauthorizedAccessException(ExceptionContext context)
     {


### PR DESCRIPTION
### Fixed the way I handle erros from handling them like crap to handling them properly
Implemented DuplicateIdentiferException for when creating App/AppToken/Service/Action to be thrown if String identifier already exists in the given context.
Implemented ForbiddenAccesException used to block request the user isn't authorized to do. Like added serviceOwners to a service you don't own etc.
Rewrote test to account for the new errors instead of just expecting NotFoundException. 
Some Query methods threw errors if the user didn't have any data on the requested endpoint. I've changed this so that instead of throwing and error if the user has no services and calls GetMyServices, to now instead just return and empty array of services.
Only queries where and Id is given as a parameter will the queries throw forbiddenAccesException. For example GetServiceById(Id=1) but the user doesn't own that service.