### PR TITLE
Feature/itm 386

### DIFF
--- a/backend/Application.UnitTests/ApplicationDbContextFactory.cs
+++ b/backend/Application.UnitTests/ApplicationDbContextFactory.cs
@@ -142,7 +142,7 @@ namespace Application.UnitTests
 
       context.Applications.AddRange(
         new ApplicationEntity { Id = 1, Title = "App 1", Description = "The First", AppIdentifier = "app_one"},
-        new ApplicationEntity { Id = 2, Title = "App 2", Description = "The Second", AppIdentifier = "app_two"},
+        new ApplicationEntity { Id = 2, Title = "App 2", Description = "The Second", AppIdentifier = "app_two", AppSecretGenerated = true},
         new ApplicationEntity { Id = 3, Title = "App 3", Description = "The Third" , AppIdentifier = "app_three"}
         );
 

--- a/backend/Application.UnitTests/Applications/Commands/CreateAppSecret/CreateAppSecretCommandTest.cs
+++ b/backend/Application.UnitTests/Applications/Commands/CreateAppSecret/CreateAppSecretCommandTest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Applications;
+using Application.Applications.Commands.CreateApplication;
+using Application.Applications.Commands.CreateAppSecret;
+using Application.Common.Exceptions;
+using AuthService.Client;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.UnitTests.Applications.Commands.CreateAppSecret
+{
+  public class CreateAppSecretCommandTest : CommandTestBase
+  {
+    [Fact]
+    public async Task Handle_CorrectUserAndAppId_ReturnsApplicationResult()
+    {
+      var command = new CreateAppSecretCommand()
+      {
+        AppId = 1
+      };
+      var handler = new CreateAppSecretCommand.CreateAppSecretCommandHandler(Context, AuthCient, CurrentUserServiceMock.Object);
+
+      var result = await handler.Handle(command, CancellationToken.None);
+
+      result.Should().BeOfType(typeof(ApplicationOutput));
+      result.Should().NotBeNull();
+      result.AppIdentifer.Should().NotBeNullOrEmpty();
+      result.AppSecret.Should().NotBeNullOrEmpty();
+
+      var entity = Context.Applications.Find(command.AppId);
+      entity.AppSecretGenerated.Should().BeTrue(); // The command should update the boolean of the AppEntity so the secret can't be fetched again
+    }
+    [Fact]
+    public void Handle_InvalidAppId_ShouldThrowError()
+    {
+      var command = new CreateAppSecretCommand()
+      {
+        AppId = 99
+      };
+      var handler = new CreateAppSecretCommand.CreateAppSecretCommandHandler(Context, AuthCient, CurrentUserServiceMock.Object);
+      Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
+
+      action.Should().Throw<NotFoundException>();
+    }
+    [Fact]
+    public void Handle_AppSecretAlreadyGenerated_ShouldThrowError()
+    {
+      var command = new CreateAppSecretCommand()
+      {
+        AppId = 2 //Application 2 already generated AppSecret once
+      };
+      var handler = new CreateAppSecretCommand.CreateAppSecretCommandHandler(Context, AuthCient, CurrentUserServiceMock.Object);
+      Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
+
+      action.Should().Throw<ForbiddenAccessException>().WithMessage("AppSecret has already been retrieved once, and can't be retrieved again");
+    }
+    [Fact]
+    public void Handle_InvalidUser_ShouldThrowError()
+    {
+      var command = new CreateAppSecretCommand()
+      {
+        AppId = 1
+      };
+      var handler = new CreateAppSecretCommand.CreateAppSecretCommandHandler(Context, AuthCient, InvalidUserServiceMock.Object);
+      Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
+
+      action.Should().Throw<ForbiddenAccessException>();
+    }
+  }
+}

--- a/backend/Application.UnitTests/Applications/Commands/CreateApplication/CreateApplicationCommandTest.cs
+++ b/backend/Application.UnitTests/Applications/Commands/CreateApplication/CreateApplicationCommandTest.cs
@@ -24,14 +24,13 @@ namespace Application.UnitTests.Applications.Commands.CreateApplication
           AppIdentifier = "test_application"
         }
       };
-      var handler = new CreateApplicationCommand.CreateApplicationCommandHandler(Context, AuthCient, CurrentUserServiceMock.Object);
+      var handler = new CreateApplicationCommand.CreateApplicationCommandHandler(Context, CurrentUserServiceMock.Object);
 
       var result = await handler.Handle(command, CancellationToken.None);
 
-      result.appId.Should().NotBe(null);
-      result.AppSecret.Should().NotBeNullOrEmpty();
+      result.Should().NotBe(null);
 
-      var entity = Context.Applications.Find(result.appId);
+      var entity = Context.Applications.Find(result);
       entity.Should().NotBeNull();
       entity.Title.Should().Be(command.Application.Title);
       entity.Description.Should().Be(command.Application.Description);
@@ -49,7 +48,7 @@ namespace Application.UnitTests.Applications.Commands.CreateApplication
           AppIdentifier = "app_one" //This identifier already exists in the DbContextFactory
         }
       };
-      var handler = new CreateApplicationCommand.CreateApplicationCommandHandler(Context, AuthCient, CurrentUserServiceMock.Object);
+      var handler = new CreateApplicationCommand.CreateApplicationCommandHandler(Context, CurrentUserServiceMock.Object);
       Func<Task> action = async () => await handler.Handle(command, CancellationToken.None);
 
       action.Should().Throw<DuplicateIdentifierException>();

--- a/backend/Application/Applications/ApplicationIdDto.cs
+++ b/backend/Application/Applications/ApplicationIdDto.cs
@@ -11,6 +11,7 @@ namespace Application.Applications
   public class ApplicationIdDto : ApplicationDto
   {
     public int Id { get; set; }
+    public bool AppSecretGenerated { get; set; }
 
     public void Mapping(Profile profile)
     {

--- a/backend/Application/Applications/Commands/CreateAppSecret/CreateAppSecretCommand.cs
+++ b/backend/Application/Applications/Commands/CreateAppSecret/CreateAppSecretCommand.cs
@@ -1,0 +1,57 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Applications.Commands.CreateApplication;
+using Application.Common.Exceptions;
+using Application.Common.Interfaces;
+using Application.Common.Security;
+using AuthService.Client;
+using Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Applications.Commands.CreateAppSecret
+{
+  [Authorize]
+  public class CreateAppSecretCommand : IRequest<ApplicationOutput>
+  {
+    public int AppId { get; set; }
+
+    public class CreateAppSecretCommandHandler : IRequestHandler<CreateAppSecretCommand, ApplicationOutput>
+    {
+      private readonly IApplicationDbContext _context;
+
+      private readonly IAuthClient _authClient;
+
+      private readonly ICurrentUserService _currentUserService;
+
+      public CreateAppSecretCommandHandler(IApplicationDbContext context, IAuthClient authClient, ICurrentUserService currentUserService)
+      {
+        _context = context;
+        _authClient = authClient;
+        _currentUserService = currentUserService;
+      }
+
+      public async Task<ApplicationOutput> Handle(CreateAppSecretCommand request, CancellationToken cancellationToken)
+      {
+        var application = await _context.Applications.FindAsync(request.AppId);
+
+        if (application == null) throw new NotFoundException(nameof(ApplicationEntity), request.AppId);
+        if (application.AppSecretGenerated) throw new ForbiddenAccessException("AppSecret has already been retrieved once, and can't be retrieved again");
+        if (!await _context.AppOwners.AnyAsync(e => e.ApplicationId == request.AppId && e.Email == _currentUserService.UserEmail, cancellationToken))
+        {
+          throw new ForbiddenAccessException(nameof(ApplicationEntity), request.AppId);
+        }
+
+        application.AppSecretGenerated = true;
+        await _context.SaveChangesAsync(cancellationToken);
+
+        var authResult = await _authClient.AppAsync(new ApplicationInput
+        {
+          AppIdentifer = application.AppIdentifier
+        }, cancellationToken);
+
+        return authResult;
+      }
+    }
+  }
+}

--- a/backend/Application/Applications/Commands/CreateAppSecret/CreateAppSecretCommand.cs
+++ b/backend/Application/Applications/Commands/CreateAppSecret/CreateAppSecretCommand.cs
@@ -8,12 +8,14 @@ using AuthService.Client;
 using Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
 
 namespace Application.Applications.Commands.CreateAppSecret
 {
   [Authorize]
   public class CreateAppSecretCommand : IRequest<ApplicationOutput>
   {
+    [JsonIgnore]
     public int AppId { get; set; }
 
     public class CreateAppSecretCommandHandler : IRequestHandler<CreateAppSecretCommand, ApplicationOutput>

--- a/backend/Application/Applications/Commands/CreateAppSecret/CreateAppSecretCommandValidation.cs
+++ b/backend/Application/Applications/Commands/CreateAppSecret/CreateAppSecretCommandValidation.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Application.Applications.Commands.CreateAppSecret
+{
+  public class CreateAppSecretCommandValidation : AbstractValidator<CreateAppSecretCommand>
+  {
+    public CreateAppSecretCommandValidation()
+    {
+      RuleFor(e => e.AppId)
+        .NotNull();
+    }
+  }
+}

--- a/backend/Application/Applications/Commands/CreateApplication/CreateApplicationCommand.cs
+++ b/backend/Application/Applications/Commands/CreateApplication/CreateApplicationCommand.cs
@@ -13,26 +13,23 @@ using Microsoft.EntityFrameworkCore;
 namespace Application.Applications.Commands.CreateApplication
 {
   [Authorize]
-  public class CreateApplicationCommand : IRequest<CreateAppResult>
+  public class CreateApplicationCommand : IRequest<int>
   {
     public ApplicationDto Application { get; set; }
 
-    public class CreateApplicationCommandHandler : IRequestHandler<CreateApplicationCommand, CreateAppResult>
+    public class CreateApplicationCommandHandler : IRequestHandler<CreateApplicationCommand, int>
     {
       private readonly IApplicationDbContext _context;
 
-      private readonly IAuthClient _authClient;
-
       private readonly ICurrentUserService _currentUserService;
 
-      public CreateApplicationCommandHandler(IApplicationDbContext context, IAuthClient authClient, ICurrentUserService currentUserService)
+      public CreateApplicationCommandHandler(IApplicationDbContext context, ICurrentUserService currentUserService)
       {
         _context = context;
-        _authClient = authClient;
         _currentUserService = currentUserService;
       }
 
-      public async Task<CreateAppResult> Handle(CreateApplicationCommand request, CancellationToken cancellationToken)
+      public async Task<int> Handle(CreateApplicationCommand request, CancellationToken cancellationToken)
       {
         if (await _context.Applications.AnyAsync(e => e.AppIdentifier == request.Application.AppIdentifier, cancellationToken))
         {
@@ -57,12 +54,7 @@ namespace Application.Applications.Commands.CreateApplication
         _context.AppOwners.Add((applicationOwner));
         await _context.SaveChangesAsync(cancellationToken);
 
-        var authResult = await _authClient.AppAsync(new ApplicationInput {
-          AppIdentifer = application.AppIdentifier
-        }, cancellationToken);
-        var result = new CreateAppResult{appId = application.Id, AppSecret = authResult.AppSecret};
-
-        return result;
+        return application.Id;
       }
     }
   }

--- a/backend/Application/Common/Exceptions/ForbiddenAccessException.cs
+++ b/backend/Application/Common/Exceptions/ForbiddenAccessException.cs
@@ -8,6 +8,10 @@ namespace Application.Common.Exceptions
         : base()
     {
     }
+    public ForbiddenAccessException(string message)
+      : base(message)
+    {
+    }
     public ForbiddenAccessException(string name, object key)
       : base($"Entity \"{name}\" ({key}) you are not authorized for the given {name}")
     {

--- a/backend/Domain/Entities/ApplicationEntity.cs
+++ b/backend/Domain/Entities/ApplicationEntity.cs
@@ -12,5 +12,6 @@ namespace Domain.Entities
     public string Title { get; set; }
     public string Description { get; set; }
     public string AppIdentifier { get; set; }
+    public bool AppSecretGenerated { get; set; } = false;
   }
 }

--- a/backend/Infrastructure/Persistence/Configurations/AppTokenConfiguration.cs
+++ b/backend/Infrastructure/Persistence/Configurations/AppTokenConfiguration.cs
@@ -15,8 +15,7 @@ namespace Infrastructure.Persistence.Configurations
         .HasForeignKey(e => e.AppTokenId)
         .IsRequired(true);
       builder.Property(e => e.Description)
-        .IsRequired(true)
-        .HasMaxLength(800);
+        .IsRequired(true);
       builder.Property(e => e.State)
         .IsRequired(true);
       builder.Property(e => e.TokenIdentifier)

--- a/backend/Infrastructure/Persistence/Configurations/ApplicationEntityConfiguration.cs
+++ b/backend/Infrastructure/Persistence/Configurations/ApplicationEntityConfiguration.cs
@@ -14,6 +14,8 @@ namespace Infrastructure.Persistence.Configurations
       builder.Property(e => e.AppIdentifier)
         .HasMaxLength(200)
         .IsRequired(true);
+      builder.Property(e => e.AppSecretGenerated)
+        .IsRequired();
     }
   }
 }

--- a/backend/Infrastructure/Persistence/Migrations/20210428134539_TodoEntity_and.Designer.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20210428134539_TodoEntity_and.Designer.cs
@@ -10,8 +10,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20210420065738_ActionIdentifier")]
-    partial class ActionIdentifier
+    [Migration("20210428134539_TodoEntity_and")]
+    partial class TodoEntity_and
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -87,8 +87,7 @@ namespace Infrastructure.Persistence.Migrations
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasMaxLength(800)
-                        .HasColumnType("nvarchar(800)");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("State")
                         .HasColumnType("int");
@@ -144,6 +143,9 @@ namespace Infrastructure.Persistence.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
+
+                    b.Property<bool>("AppSecretGenerated")
+                        .HasColumnType("bit");
 
                     b.Property<string>("Description")
                         .HasColumnType("nvarchar(max)");

--- a/backend/Infrastructure/Persistence/Migrations/20210428134539_TodoEntity_and.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20210428134539_TodoEntity_and.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Infrastructure.Persistence.Migrations
 {
-    public partial class ActionIdentifier : Migration
+    public partial class TodoEntity_and : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -29,7 +29,8 @@ namespace Infrastructure.Persistence.Migrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Title = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
                     Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    AppIdentifier = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false)
+                    AppIdentifier = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    AppSecretGenerated = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -100,7 +101,7 @@ namespace Infrastructure.Persistence.Migrations
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     TokenIdentifier = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
-                    Description = table.Column<string>(type: "nvarchar(800)", maxLength: 800, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     State = table.Column<int>(type: "int", nullable: false),
                     ApplicationId = table.Column<int>(type: "int", nullable: false)
                 },

--- a/backend/Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -85,8 +85,7 @@ namespace Infrastructure.Persistence.Migrations
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasMaxLength(800)
-                        .HasColumnType("nvarchar(800)");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("State")
                         .HasColumnType("int");
@@ -142,6 +141,9 @@ namespace Infrastructure.Persistence.Migrations
                         .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
+
+                    b.Property<bool>("AppSecretGenerated")
+                        .HasColumnType("bit");
 
                     b.Property<string>("Description")
                         .HasColumnType("nvarchar(max)");

--- a/backend/Web/Controllers/ApplicationController.cs
+++ b/backend/Web/Controllers/ApplicationController.cs
@@ -7,6 +7,7 @@ using Application.ApplicationOwners.Commands.CreateApplicationOwners;
 using Application.ApplicationOwners.Queries.GetAppOwnersByAppId;
 using Application.Applications;
 using Application.Applications.Commands.CreateApplication;
+using Application.Applications.Commands.CreateAppSecret;
 using Application.Applications.Commands.UpdateApplication;
 using Application.Applications.Queries.GetApplications;
 using Application.AppTokenActions.Commands;
@@ -29,7 +30,7 @@ namespace Web.Controllers
   public class ApplicationController : ApiControllerBase
   {
     [HttpPost]
-    public async Task<ActionResult<CreateAppResult>> CreateApplication(CreateApplicationCommand command)
+    public async Task<ActionResult<int>> CreateApplication(CreateApplicationCommand command)
     {
       return await Mediator.Send(command);
     }
@@ -116,6 +117,13 @@ namespace Web.Controllers
       command.Id = id;
       await Mediator.Send(command);
       return NoContent();
+    }
+    [HttpPost("{id}/GenerateAppSecret")]
+    public async Task<ActionResult<ApplicationOutput>> GenerateAppSecret([FromRoute] int id, CreateAppSecretCommand command)
+    {
+      command.AppId = id;
+
+      return await Mediator.Send(command);
     }
   }
 }

--- a/frontend/src/components/ApplicationScreen/AppSecret/AppSecretBanner.tsx
+++ b/frontend/src/components/ApplicationScreen/AppSecret/AppSecretBanner.tsx
@@ -18,8 +18,8 @@ const AppSecretBanner: FC = () => {
         bg={appSecretBannerBg}>
         <HStack spacing="3">
           <Text fontWeight="medium" marginEnd="2">
-            You have not generated you AppSecret for this Application. This is required to generate
-            your JWT
+            You have not generated your AppSecret for this Application. This is required to generate
+            your AppTokens and JWT
           </Text>
         </HStack>
         <GenerateAppSecretTriggerBtn />

--- a/frontend/src/components/ApplicationScreen/AppSecret/AppSecretBanner.tsx
+++ b/frontend/src/components/ApplicationScreen/AppSecret/AppSecretBanner.tsx
@@ -1,0 +1,31 @@
+import { Box, HStack, Stack, Text } from "@chakra-ui/react";
+import { useColors } from "hooks/useColors";
+import { FC } from "react";
+
+import GenerateAppSecretTriggerBtn from "./GenerateAppSecretTriggerBtn";
+
+const AppSecretBanner: FC = () => {
+  const { appSecretBannerBg } = useColors();
+  return (
+    <Box w="full" as="section" pb="12">
+      <Stack
+        direction={{ base: "column", sm: "row" }}
+        justifyContent="center"
+        alignItems="center"
+        py="3"
+        px={{ base: "3", md: "6", lg: "8" }}
+        color="white"
+        bg={appSecretBannerBg}>
+        <HStack spacing="3">
+          <Text fontWeight="medium" marginEnd="2">
+            You have not generated you AppSecret for this Application. This is required to generate
+            your JWT
+          </Text>
+        </HStack>
+        <GenerateAppSecretTriggerBtn />
+      </Stack>
+    </Box>
+  );
+};
+
+export default AppSecretBanner;

--- a/frontend/src/components/ApplicationScreen/AppSecret/AppSecretResult.tsx
+++ b/frontend/src/components/ApplicationScreen/AppSecret/AppSecretResult.tsx
@@ -1,0 +1,107 @@
+import {
+  Box,
+  Button,
+  Center,
+  Divider,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useClipboard,
+  useDisclosure,
+  useToast
+} from "@chakra-ui/react";
+import React, { FC, useCallback, useState } from "react";
+import { genApplicationClient } from "services/backend/apiClients";
+import { CreateAppSecretCommand } from "services/backend/nswagts";
+
+type Props = {
+  currAppId: number;
+  submitCallback: () => void;
+};
+
+const AppSecretResult: FC<Props> = ({ submitCallback, currAppId }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [isLoading, setIsLoading] = useState(false);
+  const [appSecret, setAppSecret] = useState("");
+  const { hasCopied, onCopy } = useClipboard(appSecret);
+  const toast = useToast();
+
+  const generateAppSecret = useCallback(async () => {
+    setIsLoading(true);
+    const applicationClient = await genApplicationClient();
+    try {
+      const authResult = await applicationClient.generateAppSecret(
+        currAppId,
+        new CreateAppSecretCommand({})
+      );
+      setAppSecret(authResult.appSecret);
+      onOpen();
+    } catch (error) {
+      toast({
+        description: `GenerateAppSecret responded: ${error}`,
+        status: "error",
+        duration: 5000,
+        isClosable: true
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return (
+    <Center>
+      <Box width="full" p={6}>
+        <Text>
+          This can only be done once and you are responsible for keeping it safe and secure. The
+          AppSecret is used for signing your AppTokens in order to generate a JWT.
+        </Text>
+        <Button
+          isLoading={isLoading}
+          onClick={() => generateAppSecret()}
+          colorScheme="green"
+          mt="10px">
+          Generate AppSecret
+        </Button>
+      </Box>
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          onClose();
+          submitCallback();
+        }}
+        scrollBehavior="inside"
+        size="2xl">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Here is your AppSecret</ModalHeader>
+          <ModalCloseButton />
+          <Divider />
+          <ModalBody>
+            <Text>{appSecret}</Text>
+          </ModalBody>
+          <Divider />
+          <ModalFooter>
+            <Button colorScheme="blue" onClick={onCopy} mr={2}>
+              {hasCopied ? "Copied" : "Copy"}
+            </Button>
+            <Button
+              colorScheme="red"
+              mr={3}
+              onClick={() => {
+                onClose();
+                submitCallback();
+              }}>
+              Close
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </Center>
+  );
+};
+export default AppSecretResult;

--- a/frontend/src/components/ApplicationScreen/AppSecret/AppSecretResult.tsx
+++ b/frontend/src/components/ApplicationScreen/AppSecret/AppSecretResult.tsx
@@ -21,12 +21,13 @@ import { CreateAppSecretCommand } from "services/backend/nswagts";
 
 type Props = {
   currAppId: number;
+  isLoading: boolean;
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   submitCallback: () => void;
 };
 
-const AppSecretResult: FC<Props> = ({ submitCallback, currAppId }) => {
+const AppSecretResult: FC<Props> = ({ submitCallback, currAppId, isLoading, setIsLoading }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [isLoading, setIsLoading] = useState(false);
   const [appSecret, setAppSecret] = useState("");
   const { hasCopied, onCopy } = useClipboard(appSecret);
   const toast = useToast();
@@ -69,6 +70,8 @@ const AppSecretResult: FC<Props> = ({ submitCallback, currAppId }) => {
         </Button>
       </Box>
       <Modal
+        closeOnOverlayClick={false}
+        closeOnEsc={false}
         isOpen={isOpen}
         onClose={() => {
           onClose();

--- a/frontend/src/components/ApplicationScreen/AppSecret/GenerateAppSecretTriggerBtn.tsx
+++ b/frontend/src/components/ApplicationScreen/AppSecret/GenerateAppSecretTriggerBtn.tsx
@@ -1,0 +1,60 @@
+import {
+  Box,
+  Button,
+  Divider,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure
+} from "@chakra-ui/react";
+import { AppViewContext } from "contexts/AppViewContext";
+import React, { FC, useContext } from "react";
+
+import AppSecretResult from "./AppSecretResult";
+
+const GenerateAppSecretTriggerBtn: FC = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { currApplication, fetchApps } = useContext(AppViewContext);
+
+  return (
+    <>
+      <Button colorScheme="green" onClick={onOpen}>
+        Generate AppSecret
+      </Button>
+
+      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside" size="3xl">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>
+            Are you sure you a ready to generate your Applications AppSecret?
+          </ModalHeader>
+          <ModalCloseButton />
+          <Divider />
+          <ModalBody>
+            <Box>
+              <AppSecretResult
+                currAppId={currApplication.id}
+                submitCallback={() => {
+                  onClose();
+                  fetchApps();
+                }}
+              />
+            </Box>
+          </ModalBody>
+          <Divider />
+          <ModalFooter>
+            <Button colorScheme="blue" mr={3} onClick={onClose}>
+              Close
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default GenerateAppSecretTriggerBtn;

--- a/frontend/src/components/ApplicationScreen/AppSecret/GenerateAppSecretTriggerBtn.tsx
+++ b/frontend/src/components/ApplicationScreen/AppSecret/GenerateAppSecretTriggerBtn.tsx
@@ -12,13 +12,14 @@ import {
   useDisclosure
 } from "@chakra-ui/react";
 import { AppViewContext } from "contexts/AppViewContext";
-import React, { FC, useContext } from "react";
+import React, { FC, useContext, useState } from "react";
 
 import AppSecretResult from "./AppSecretResult";
 
 const GenerateAppSecretTriggerBtn: FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { currApplication, fetchApps } = useContext(AppViewContext);
+  const { currApplication, setNewCurrApp } = useContext(AppViewContext);
+  const [isLoading, setIsLoading] = useState(false);
 
   return (
     <>
@@ -26,28 +27,36 @@ const GenerateAppSecretTriggerBtn: FC = () => {
         Generate AppSecret
       </Button>
 
-      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside" size="3xl">
+      <Modal
+        closeOnEsc={!isLoading}
+        closeOnOverlayClick={!isLoading}
+        isOpen={isOpen}
+        onClose={onClose}
+        scrollBehavior="inside"
+        size="3xl">
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>
             Are you sure you a ready to generate your Applications AppSecret?
           </ModalHeader>
-          <ModalCloseButton />
+          <ModalCloseButton isDisabled={isLoading} />
           <Divider />
           <ModalBody>
             <Box>
               <AppSecretResult
                 currAppId={currApplication.id}
+                isLoading={isLoading}
+                setIsLoading={setIsLoading}
                 submitCallback={() => {
                   onClose();
-                  fetchApps();
+                  setNewCurrApp(currApplication.id);
                 }}
               />
             </Box>
           </ModalBody>
           <Divider />
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
+            <Button isDisabled={isLoading} colorScheme="blue" mr={3} onClick={onClose}>
               Close
             </Button>
           </ModalFooter>

--- a/frontend/src/components/ApplicationScreen/AppSecret/GenerateAppSecretTriggerBtn.tsx
+++ b/frontend/src/components/ApplicationScreen/AppSecret/GenerateAppSecretTriggerBtn.tsx
@@ -36,9 +36,7 @@ const GenerateAppSecretTriggerBtn: FC = () => {
         size="3xl">
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>
-            Are you sure you a ready to generate your Applications AppSecret?
-          </ModalHeader>
+          <ModalHeader>Are you sure you want to generate your Applications AppSecret?</ModalHeader>
           <ModalCloseButton isDisabled={isLoading} />
           <Divider />
           <ModalBody>

--- a/frontend/src/components/ApplicationScreen/Application/CreateApplicationTriggerBtn.tsx
+++ b/frontend/src/components/ApplicationScreen/Application/CreateApplicationTriggerBtn.tsx
@@ -39,7 +39,7 @@ const CreateApplicationTriggerBtn: FC = () => {
       );
       setNewCurrApp(appId);
       toast({
-        description: `App created appSecret: ${appId}`,
+        description: `Application created`,
         status: "success",
         duration: 5000,
         isClosable: true

--- a/frontend/src/components/ApplicationScreen/Application/CreateApplicationTriggerBtn.tsx
+++ b/frontend/src/components/ApplicationScreen/Application/CreateApplicationTriggerBtn.tsx
@@ -28,7 +28,7 @@ const CreateApplicationTriggerBtn: FC = () => {
   const addApplication = useCallback(async (title: string, description: string) => {
     const applicationClient = await genApplicationClient();
     try {
-      const appResult = await applicationClient.createApplication(
+      const appId = await applicationClient.createApplication(
         new CreateApplicationCommand({
           application: new ApplicationDto({
             title: title,
@@ -37,9 +37,9 @@ const CreateApplicationTriggerBtn: FC = () => {
           })
         })
       );
-      setNewCurrApp(appResult.appId);
+      setNewCurrApp(appId);
       toast({
-        description: `App created appSecret: ${appResult.appSecret}`,
+        description: `App created appSecret: ${appId}`,
         status: "success",
         duration: 5000,
         isClosable: true

--- a/frontend/src/components/ApplicationScreen/ApplicationInfo.tsx
+++ b/frontend/src/components/ApplicationScreen/ApplicationInfo.tsx
@@ -4,6 +4,7 @@ import { AppViewContext } from "contexts/AppViewContext";
 import React, { FC, useContext, useEffect, useState } from "react";
 import { ApplicationDto, IApplicationDto } from "services/backend/nswagts";
 
+import AppSecretBanner from "./AppSecret/AppSecretBanner";
 import AddOwnersTriggerBtn from "./Owners/AddOwnersTriggerBtn";
 import AppOwnerOverview from "./Owners/AppOwnerOverview";
 import CreateTokenTriggerBtn from "./Tokens/CreateTokenTriggerBtn";
@@ -27,25 +28,30 @@ const ApplicationInfo: FC = () => {
   if (!currApplication) return null;
 
   return (
-    <Center>
-      <Container pt="30px" pb="15px" w="6xl" maxW="unset">
-        <VStack width="full" align="left">
-          <Flex w="full">
-            <AddOwnersTriggerBtn />
-            <Spacer />
-            <CreateTokenTriggerBtn />
-          </Flex>
-          <AppOwnerOverview />
-          <Box pt="10" width={0.65}>
-            <Heading>{localFormData.title}</Heading>
-            <MarkdownViewer value={localFormData.description} />
-          </Box>
-          <Box pt="10" width="full">
-            <TokenTable />
-          </Box>
+    <>
+      <Flex>{!currApplication.appSecretGenerated && <AppSecretBanner />}</Flex>
+      <Center w="full">
+        <VStack>
+          <Container pt="30px" pb="15px" w="6xl" maxW="unset">
+            <VStack width="full" align="left">
+              <Flex w="full">
+                <AddOwnersTriggerBtn />
+                <Spacer />
+                <CreateTokenTriggerBtn />
+              </Flex>
+              <AppOwnerOverview />
+              <Box pt="10" width={0.65}>
+                <Heading>{localFormData.title}</Heading>
+                <MarkdownViewer value={localFormData.description} />
+              </Box>
+              <Box pt="10" width="full">
+                <TokenTable />
+              </Box>
+            </VStack>
+          </Container>
         </VStack>
-      </Container>
-    </Center>
+      </Center>
+    </>
   );
 };
 export default ApplicationInfo;

--- a/frontend/src/components/ApplicationScreen/Tokens/CreateTokenTriggerBtn.tsx
+++ b/frontend/src/components/ApplicationScreen/Tokens/CreateTokenTriggerBtn.tsx
@@ -11,6 +11,8 @@ import {
   DrawerOverlay,
   Flex,
   Spacer,
+  Tag,
+  Tooltip,
   useDisclosure,
   useToast
 } from "@chakra-ui/react";
@@ -66,11 +68,25 @@ const CreateTokenTriggerBtn: FC = () => {
   );
 
   if (currApplication == null) return null;
+  // The Create new token Btn is wrapped in a transparent Tag because of
+  //and issue with tooltips not showing on disabled buttons
   return (
     <>
-      <Button onClick={onOpen} rightIcon={<BsPlus />} colorScheme="green">
-        Create new token
-      </Button>
+      <Tooltip
+        isDisabled={currApplication.appSecretGenerated}
+        hasArrow
+        label="Generate AppSecret First">
+        <Tag bgColor="transparent">
+          <Button
+            isDisabled={!currApplication.appSecretGenerated}
+            onClick={onOpen}
+            rightIcon={<BsPlus />}
+            colorScheme="green">
+            Create new token
+          </Button>
+        </Tag>
+      </Tooltip>
+
       <ServiceLibraryDrawer Open={open} setOpen={setOpen} />
 
       <Drawer onClose={onClose} isOpen={isOpen} size="full">

--- a/frontend/src/hooks/useColors.ts
+++ b/frontend/src/hooks/useColors.ts
@@ -10,6 +10,7 @@ export const useColors = () => {
   const appHeaderBg = useColorModeValue("purple.500", "purple.300");
   const serviceHeaderBg = useColorModeValue("orange.400", "orange.600");
   const overviewHeaderBg = useColorModeValue("blue.400", "blue.200");
+  const appSecretBannerBg = useColorModeValue("red.400", "red.300");
 
   return {
     hoverBg,
@@ -18,6 +19,7 @@ export const useColors = () => {
     mainBg,
     appHeaderBg,
     serviceHeaderBg,
-    overviewHeaderBg
+    overviewHeaderBg,
+    appSecretBannerBg
   };
 };

--- a/frontend/src/pages/OverviewScreen/Index.tsx
+++ b/frontend/src/pages/OverviewScreen/Index.tsx
@@ -1,9 +1,11 @@
-import { Box, Center, Container, Flex, SimpleGrid } from "@chakra-ui/layout";
+import { Button } from "@chakra-ui/button";
+import { Box, Center, Container, Flex, Heading, SimpleGrid, Text } from "@chakra-ui/layout";
 import OverviewHeader from "components/OverviewScreen/OverviewHeader";
 import OverviewTable from "components/OverviewScreen/OverviewTable";
 import { OverviewScreenContext } from "contexts/OverviewScreenContext";
 import { Locale } from "i18n/Locale";
 import { GetStaticProps, NextPage } from "next";
+import Link from "next/link";
 import { I18nProps } from "next-rosetta";
 import { useCallback, useEffect, useReducer } from "react";
 import ListReducer, { ListReducerActionType } from "react-list-reducer";
@@ -71,12 +73,44 @@ const OverviewScreen: NextPage = () => {
               minChildWidth="300px"
               spacingX="40px"
               spacingY="20px">
-              <Box>
-                <OverviewTable tableData={applications} tableHeading="Applications" />
-              </Box>
-              <Box>
-                <OverviewTable tableData={services} tableHeading="Services" />
-              </Box>
+              {applications.length != 0 ? (
+                <Box>
+                  <OverviewTable tableData={applications} tableHeading="Applications" />
+                </Box>
+              ) : (
+                <Flex direction="column">
+                  <Heading mb="10" size="h3">
+                    Applications:
+                  </Heading>
+                  <Text fontSize="lg">
+                    You have no applications yet, go to Application Page to create one
+                  </Text>
+                  <Link href="/ApplicationScreen">
+                    <Button mt="10px" w="max-content" colorScheme="blue">
+                      Application Page
+                    </Button>
+                  </Link>
+                </Flex>
+              )}
+              {services.length != 0 ? (
+                <Box>
+                  <OverviewTable tableData={services} tableHeading="Services" />
+                </Box>
+              ) : (
+                <Flex direction="column">
+                  <Heading mb="10" size="h3">
+                    Services:
+                  </Heading>
+                  <Text fontSize="lg">
+                    You have no services yet, go to Service Page to create one
+                  </Text>
+                  <Link href="/ServiceScreen">
+                    <Button mt="10px" w="max-content" colorScheme="blue">
+                      Service Page
+                    </Button>
+                  </Link>
+                </Flex>
+              )}
             </SimpleGrid>
           </Container>
         </Center>

--- a/frontend/src/services/backend/nswagts.ts
+++ b/frontend/src/services/backend/nswagts.ts
@@ -1929,6 +1929,7 @@ export interface IUpdateApplicationCommand {
 
 export class ApplicationIdDto extends ApplicationDto implements IApplicationIdDto {
     id?: number;
+    appSecretGenerated?: boolean;
 
     constructor(data?: IApplicationIdDto) {
         super(data);
@@ -1938,6 +1939,7 @@ export class ApplicationIdDto extends ApplicationDto implements IApplicationIdDt
         super.init(_data);
         if (_data) {
             this.id = _data["id"] !== undefined ? _data["id"] : <any>null;
+            this.appSecretGenerated = _data["appSecretGenerated"] !== undefined ? _data["appSecretGenerated"] : <any>null;
         }
     }
 
@@ -1951,6 +1953,7 @@ export class ApplicationIdDto extends ApplicationDto implements IApplicationIdDt
     toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
         data["id"] = this.id !== undefined ? this.id : <any>null;
+        data["appSecretGenerated"] = this.appSecretGenerated !== undefined ? this.appSecretGenerated : <any>null;
         super.toJSON(data);
         return data; 
     }
@@ -1958,6 +1961,7 @@ export class ApplicationIdDto extends ApplicationDto implements IApplicationIdDt
 
 export interface IApplicationIdDto extends IApplicationDto {
     id?: number;
+    appSecretGenerated?: boolean;
 }
 
 export class AppOverviewDto implements IAppOverviewDto {
@@ -2956,7 +2960,6 @@ export interface IApplicationOutput {
 }
 
 export class CreateAppSecretCommand implements ICreateAppSecretCommand {
-    appId?: number;
 
     constructor(data?: ICreateAppSecretCommand) {
         if (data) {
@@ -2968,9 +2971,6 @@ export class CreateAppSecretCommand implements ICreateAppSecretCommand {
     }
 
     init(_data?: any) {
-        if (_data) {
-            this.appId = _data["appId"] !== undefined ? _data["appId"] : <any>null;
-        }
     }
 
     static fromJS(data: any): CreateAppSecretCommand {
@@ -2982,13 +2982,11 @@ export class CreateAppSecretCommand implements ICreateAppSecretCommand {
 
     toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
-        data["appId"] = this.appId !== undefined ? this.appId : <any>null;
         return data; 
     }
 }
 
 export interface ICreateAppSecretCommand {
-    appId?: number;
 }
 
 export class CreateExampleChildCommand implements ICreateExampleChildCommand {

--- a/frontend/src/services/backend/nswagts.ts
+++ b/frontend/src/services/backend/nswagts.ts
@@ -126,7 +126,7 @@ export class ClientBase {
 }
 
 export interface IApplicationClient {
-    createApplication(command: CreateApplicationCommand): Promise<CreateAppResult>;
+    createApplication(command: CreateApplicationCommand): Promise<number>;
     getAllApplications(): Promise<ApplicationIdDto[]>;
     updateApplication(id: number, command: UpdateApplicationCommand): Promise<FileResponse>;
     getAllMyApplicationsOverview(): Promise<AppOverviewDto[]>;
@@ -141,6 +141,7 @@ export interface IApplicationClient {
     createAuthAppToken(aid: string | null, command: CreateAuthAppTokenCommand, xToken?: string | null | undefined): Promise<TokenOutput>;
     updateAppTokenActions(id: number, command: UpdateAppTokenActionsCommand): Promise<FileResponse>;
     updateTokenState(id: number, command: UpdateAppTokenStateCommand): Promise<FileResponse>;
+    generateAppSecret(id: number, command: CreateAppSecretCommand): Promise<ApplicationOutput>;
 }
 
 export class ApplicationClient extends ClientBase implements IApplicationClient {
@@ -154,7 +155,7 @@ export class ApplicationClient extends ClientBase implements IApplicationClient 
         this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
     }
 
-    createApplication(command: CreateApplicationCommand): Promise<CreateAppResult> {
+    createApplication(command: CreateApplicationCommand): Promise<number> {
         let url_ = this.baseUrl + "/api/Application";
         url_ = url_.replace(/[?&]$/, "");
 
@@ -176,14 +177,14 @@ export class ApplicationClient extends ClientBase implements IApplicationClient 
         });
     }
 
-    protected processCreateApplication(response: Response): Promise<CreateAppResult> {
+    protected processCreateApplication(response: Response): Promise<number> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
             return response.text().then((_responseText) => {
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = CreateAppResult.fromJS(resultData200);
+            result200 = resultData200 !== undefined ? resultData200 : <any>null;
             return result200;
             });
         } else if (status !== 200 && status !== 204) {
@@ -191,7 +192,7 @@ export class ApplicationClient extends ClientBase implements IApplicationClient 
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<CreateAppResult>(<any>null);
+        return Promise.resolve<number>(<any>null);
     }
 
     getAllApplications(): Promise<ApplicationIdDto[]> {
@@ -777,6 +778,49 @@ export class ApplicationClient extends ClientBase implements IApplicationClient 
             });
         }
         return Promise.resolve<FileResponse>(<any>null);
+    }
+
+    generateAppSecret(id: number, command: CreateAppSecretCommand): Promise<ApplicationOutput> {
+        let url_ = this.baseUrl + "/api/Application/{id}/GenerateAppSecret";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(command);
+
+        let options_ = <RequestInit>{
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.transformOptions(options_).then(transformedOptions_ => {
+            return this.http.fetch(url_, transformedOptions_);
+        }).then((_response: Response) => {
+            return this.transformResult(url_, _response, (_response: Response) => this.processGenerateAppSecret(_response));
+        });
+    }
+
+    protected processGenerateAppSecret(response: Response): Promise<ApplicationOutput> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = ApplicationOutput.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<ApplicationOutput>(<any>null);
     }
 }
 
@@ -1763,46 +1807,6 @@ export class UserClient extends ClientBase implements IUserClient {
         }
         return Promise.resolve<User[]>(<any>null);
     }
-}
-
-export class CreateAppResult implements ICreateAppResult {
-    appId?: number;
-    appSecret?: string | null;
-
-    constructor(data?: ICreateAppResult) {
-        if (data) {
-            for (var property in data) {
-                if (data.hasOwnProperty(property))
-                    (<any>this)[property] = (<any>data)[property];
-            }
-        }
-    }
-
-    init(_data?: any) {
-        if (_data) {
-            this.appId = _data["appId"] !== undefined ? _data["appId"] : <any>null;
-            this.appSecret = _data["appSecret"] !== undefined ? _data["appSecret"] : <any>null;
-        }
-    }
-
-    static fromJS(data: any): CreateAppResult {
-        data = typeof data === 'object' ? data : {};
-        let result = new CreateAppResult();
-        result.init(data);
-        return result;
-    }
-
-    toJSON(data?: any) {
-        data = typeof data === 'object' ? data : {};
-        data["appId"] = this.appId !== undefined ? this.appId : <any>null;
-        data["appSecret"] = this.appSecret !== undefined ? this.appSecret : <any>null;
-        return data; 
-    }
-}
-
-export interface ICreateAppResult {
-    appId?: number;
-    appSecret?: string | null;
 }
 
 export class CreateApplicationCommand implements ICreateApplicationCommand {
@@ -2909,6 +2913,82 @@ export class UpdateAppTokenStateCommand implements IUpdateAppTokenStateCommand {
 
 export interface IUpdateAppTokenStateCommand {
     newState?: TokenStates;
+}
+
+export class ApplicationOutput implements IApplicationOutput {
+    appIdentifer?: string;
+    appSecret?: string;
+
+    constructor(data?: IApplicationOutput) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.appIdentifer = _data["appIdentifer"] !== undefined ? _data["appIdentifer"] : <any>null;
+            this.appSecret = _data["appSecret"] !== undefined ? _data["appSecret"] : <any>null;
+        }
+    }
+
+    static fromJS(data: any): ApplicationOutput {
+        data = typeof data === 'object' ? data : {};
+        let result = new ApplicationOutput();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["appIdentifer"] = this.appIdentifer !== undefined ? this.appIdentifer : <any>null;
+        data["appSecret"] = this.appSecret !== undefined ? this.appSecret : <any>null;
+        return data; 
+    }
+}
+
+export interface IApplicationOutput {
+    appIdentifer?: string;
+    appSecret?: string;
+}
+
+export class CreateAppSecretCommand implements ICreateAppSecretCommand {
+    appId?: number;
+
+    constructor(data?: ICreateAppSecretCommand) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.appId = _data["appId"] !== undefined ? _data["appId"] : <any>null;
+        }
+    }
+
+    static fromJS(data: any): CreateAppSecretCommand {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateAppSecretCommand();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["appId"] = this.appId !== undefined ? this.appId : <any>null;
+        return data; 
+    }
+}
+
+export interface ICreateAppSecretCommand {
+    appId?: number;
 }
 
 export class CreateExampleChildCommand implements ICreateExampleChildCommand {


### PR DESCRIPTION
Depends on #97 
### Backend

- GeneratedAppSecret boolean on ApplicationEntity to handle only allowing the user to get GenSecret once. Defaults to False
- CreateAppSecretCommand Simply takes the Id of and App and generates the appSecret for it. Will fail if user is unAuthorized for the app or if GeneratedAppSecret already is True
- Removed Secret Generation from original CreateApplicationCommand.
### Frontend

- Added navigation and messages on overviewScreen in cause the user doesn't own any Applications or Services.
- Added AppSecretBanner that is shown after App creation to notify the user that thay haven't generated their appSecret yet.
- Banner has button to trigger modal that allows user to generate Secret for his App. Modals in this flow are harder to close to make sure the user doesn't close on accident.
- CreateTokenBtn is disabled when generatedAppSecret is false. Shows tooltip explaining why.
- Updated CreateApplicationModal to handle changes to command and request response.