### PR TITLE
Feature/itm 488

### DIFF
--- a/frontend/src/components/ApplicationScreen/AppSecret/AppSecretResult.tsx
+++ b/frontend/src/components/ApplicationScreen/AppSecret/AppSecretResult.tsx
@@ -100,6 +100,7 @@ const AppSecretResult: FC<Props> = ({ submitCallback, currAppId, isLoading, setI
               text={t("applicationScreen.tokens.appSecret.haveYouSavedAppSecret")}
               onClick={() => {
                 onClose();
+                submitCallback();
               }}
             />
             <Text>{appSecret}</Text>

--- a/frontend/src/components/ApplicationScreen/AppSecret/AppSecretResult.tsx
+++ b/frontend/src/components/ApplicationScreen/AppSecret/AppSecretResult.tsx
@@ -15,7 +15,9 @@ import {
   useDisclosure,
   useToast
 } from "@chakra-ui/react";
+import UnsavedChangesAlert from "components/Common/UnsavedChangesAlert";
 import { useLocales } from "hooks/useLocales";
+import { useUnsavedAlert } from "hooks/useUnsavedAlert";
 import React, { FC, useCallback, useState } from "react";
 import { genApplicationClient } from "services/backend/apiClients";
 import { CreateAppSecretCommand } from "services/backend/nswagts";
@@ -33,6 +35,7 @@ const AppSecretResult: FC<Props> = ({ submitCallback, currAppId, isLoading, setI
   const { hasCopied, onCopy } = useClipboard(appSecret);
   const toast = useToast();
   const { t } = useLocales();
+  const { setUnsavedChanges, alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
 
   const generateAppSecret = useCallback(async () => {
     setIsLoading(true);
@@ -62,7 +65,10 @@ const AppSecretResult: FC<Props> = ({ submitCallback, currAppId, isLoading, setI
         <Text>{t("applicationScreen.tokens.appSecret.appSecretWarning")}</Text>
         <Button
           isLoading={isLoading}
-          onClick={() => generateAppSecret()}
+          onClick={() => {
+            generateAppSecret();
+            setUnsavedChanges(true);
+          }}
           colorScheme="green"
           mt="10px">
           {t("applicationScreen.tokens.appSecret.generateSecret")}
@@ -73,8 +79,12 @@ const AppSecretResult: FC<Props> = ({ submitCallback, currAppId, isLoading, setI
         closeOnEsc={false}
         isOpen={isOpen}
         onClose={() => {
-          onClose();
-          submitCallback();
+          if (unsavedChanged) {
+            setAlertOpen(true);
+          } else {
+            submitCallback();
+            onClose();
+          }
         }}
         scrollBehavior="inside"
         size="2xl">
@@ -84,6 +94,14 @@ const AppSecretResult: FC<Props> = ({ submitCallback, currAppId, isLoading, setI
           <ModalCloseButton />
           <Divider />
           <ModalBody>
+            <UnsavedChangesAlert
+              isOpen={alertOpen}
+              setIsOpen={setAlertOpen}
+              text={t("applicationScreen.tokens.appSecret.haveYouSavedAppSecret")}
+              onClick={() => {
+                onClose();
+              }}
+            />
             <Text>{appSecret}</Text>
           </ModalBody>
           <Divider />
@@ -95,8 +113,12 @@ const AppSecretResult: FC<Props> = ({ submitCallback, currAppId, isLoading, setI
               colorScheme="red"
               mr={3}
               onClick={() => {
-                onClose();
-                submitCallback();
+                if (unsavedChanged) {
+                  setAlertOpen(true);
+                } else {
+                  submitCallback();
+                  onClose();
+                }
               }}>
               {t("commonButtons.close")}
             </Button>

--- a/frontend/src/components/ApplicationScreen/Owners/AddOwnersTriggerBtn.tsx
+++ b/frontend/src/components/ApplicationScreen/Owners/AddOwnersTriggerBtn.tsx
@@ -90,7 +90,7 @@ const AddOwnersTriggerBtn: FC = () => {
             <UnsavedChangesAlert
               isOpen={alertOpen}
               setIsOpen={setAlertOpen}
-              onClick={() => onclose}
+              onClick={() => onClose()}
             />
             <AppOwnerForm submitCallback={addOwners}></AppOwnerForm>
           </ModalBody>

--- a/frontend/src/components/ApplicationScreen/Tokens/CreateTokenTriggerBtn.tsx
+++ b/frontend/src/components/ApplicationScreen/Tokens/CreateTokenTriggerBtn.tsx
@@ -37,7 +37,7 @@ const CreateTokenTriggerBtn: FC = () => {
   const toast = useToast();
   const [open, setOpen] = useState(false);
   const { t } = useLocales();
-  const { setUnsavedChanges, alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
+  const { alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
 
   const createAppToken = useCallback(
     async (metaData: AppTokenCreateDto) => {

--- a/frontend/src/components/ApplicationScreen/Tokens/CreateTokenTriggerBtn.tsx
+++ b/frontend/src/components/ApplicationScreen/Tokens/CreateTokenTriggerBtn.tsx
@@ -17,10 +17,12 @@ import {
   useToast
 } from "@chakra-ui/react";
 import { BsPlus } from "@react-icons/all-files/bs/BsPlus";
+import UnsavedChangesAlert from "components/Common/UnsavedChangesAlert";
 import AppTokenForm from "components/Forms/Application/AppTokenForm";
 import ServiceLibraryDrawer from "components/ServiceLibrary/ServiceLibraryDrawer";
 import { AppViewContext } from "contexts/AppViewContext";
 import { useLocales } from "hooks/useLocales";
+import { useUnsavedAlert } from "hooks/useUnsavedAlert";
 import React, { FC, useCallback, useContext, useState } from "react";
 import { genApplicationClient } from "services/backend/apiClients";
 import { AppTokenCreateDto, CreateAppTokenCommand } from "services/backend/nswagts";
@@ -35,6 +37,7 @@ const CreateTokenTriggerBtn: FC = () => {
   const toast = useToast();
   const [open, setOpen] = useState(false);
   const { t } = useLocales();
+  const { setUnsavedChanges, alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
 
   const createAppToken = useCallback(
     async (metaData: AppTokenCreateDto) => {
@@ -94,17 +97,37 @@ const CreateTokenTriggerBtn: FC = () => {
 
       <ServiceLibraryDrawer Open={open} setOpen={setOpen} />
 
-      <Drawer onClose={onClose} isOpen={isOpen} size="full">
+      <Drawer
+        onClose={() => {
+          if (unsavedChanged) {
+            setAlertOpen(true);
+          } else onClose();
+        }}
+        isOpen={isOpen}
+        size="full">
         <DrawerOverlay>
           <DrawerContent>
             <DrawerHeader>
               <Flex>
                 <Box>{t("applicationScreen.modalHeaders.createNewToken")}</Box>
                 <Spacer />
-                <CloseButton onClick={() => onClose()} />
+                <CloseButton
+                  onClick={() => {
+                    if (unsavedChanged) {
+                      setAlertOpen(true);
+                    } else onClose();
+                  }}
+                />
               </Flex>
             </DrawerHeader>
             <DrawerBody>
+              <UnsavedChangesAlert
+                isOpen={alertOpen}
+                setIsOpen={setAlertOpen}
+                onClick={() => {
+                  onClose();
+                }}
+              />
               <Center height="full">
                 <Container height="full" w="4xl" maxW="unset">
                   <Flex direction="column" width="full" height="full">

--- a/frontend/src/components/ApplicationScreen/Tokens/TokenTableItem.tsx
+++ b/frontend/src/components/ApplicationScreen/Tokens/TokenTableItem.tsx
@@ -32,12 +32,12 @@ const TokenTableItem: FC<Props> = ({ token }) => {
                 await fetchUpdatedToken(token.id);
                 setOpen(true);
               }}>
-              Browse Services
+              {t("applicationScreen.tokens.actions.browseServices")}
             </Button>
           )}
           {token.state == TokenStates.AwaitingReview && (
             <SeeTokenStatusDrawer
-              buttonText={t("applicationScreen.tokens.actions.browseServices")}
+              buttonText={t("applicationScreen.tokens.actions.checkStatus")}
               submitOnOpen={() => fetchUpdatedToken(token.id)}
               submitOnClose={() => null}
             />

--- a/frontend/src/components/Common/RouteAlertModal.tsx
+++ b/frontend/src/components/Common/RouteAlertModal.tsx
@@ -1,0 +1,63 @@
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogCloseButton,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button
+} from "@chakra-ui/react";
+import { UnsavedChangesContext } from "contexts/UnsavedChangesContext";
+import { useRouter } from "next/router";
+import React, { FC, useContext, useEffect } from "react";
+
+const RouteAlertModal: FC = () => {
+  const cancelRef = React.useRef();
+  const router = useRouter();
+  const { alertOpen, setAlertOpen, unsavedChanged, setUnsavedChanges, targetUrl } = useContext(
+    UnsavedChangesContext
+  );
+
+  useEffect(() => {
+    if (!unsavedChanged) {
+      if (targetUrl) {
+        if (targetUrl == "back") router.back();
+        else router.push(targetUrl);
+      }
+    }
+  }, [unsavedChanged]);
+  return (
+    <AlertDialog
+      motionPreset="slideInBottom"
+      leastDestructiveRef={cancelRef}
+      onClose={() => setAlertOpen(true)}
+      isOpen={alertOpen}
+      isCentered>
+      <AlertDialogOverlay />
+
+      <AlertDialogContent>
+        <AlertDialogHeader>Confirm navigation</AlertDialogHeader>
+        <AlertDialogCloseButton />
+        <AlertDialogBody>
+          You have unsaved changes on this page, are you sure you want to leave the page?
+        </AlertDialogBody>
+        <AlertDialogFooter>
+          <Button ref={cancelRef} onClick={() => setAlertOpen(false)}>
+            Stay on this page
+          </Button>
+          <Button
+            colorScheme="red"
+            ml={3}
+            onClick={() => {
+              setUnsavedChanges(false);
+              setAlertOpen(false);
+            }}>
+            Leave page
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+export default RouteAlertModal;

--- a/frontend/src/components/Common/UnsavedChangesAlert.tsx
+++ b/frontend/src/components/Common/UnsavedChangesAlert.tsx
@@ -24,7 +24,12 @@ const UnsavedChangesAlert: FC<Props> = ({ isOpen, setIsOpen, onClick, text }) =>
     <AlertDialog
       motionPreset="slideInBottom"
       leastDestructiveRef={cancelRef}
-      onClose={() => setIsOpen(false)}
+      onClose={() => {
+        alert("onClick");
+
+        onClick();
+        setIsOpen(false);
+      }}
       isOpen={isOpen}
       isCentered>
       <AlertDialogOverlay />
@@ -44,8 +49,8 @@ const UnsavedChangesAlert: FC<Props> = ({ isOpen, setIsOpen, onClick, text }) =>
             ml={3}
             onClick={() => {
               setUnsavedChanges(false);
-              setIsOpen(false);
               onClick();
+              setIsOpen(false);
             }}>
             Leave
           </Button>

--- a/frontend/src/components/Common/UnsavedChangesAlert.tsx
+++ b/frontend/src/components/Common/UnsavedChangesAlert.tsx
@@ -1,0 +1,57 @@
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogCloseButton,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button
+} from "@chakra-ui/react";
+import { UnsavedChangesContext } from "contexts/UnsavedChangesContext";
+import React, { Dispatch, FC, useContext } from "react";
+type Props = {
+  isOpen: boolean;
+  setIsOpen: Dispatch<React.SetStateAction<boolean>>;
+  onClick: () => void;
+  text?: string;
+};
+const UnsavedChangesAlert: FC<Props> = ({ isOpen, setIsOpen, onClick, text }) => {
+  const cancelRef = React.useRef();
+  const { setUnsavedChanges } = useContext(UnsavedChangesContext);
+
+  return (
+    <AlertDialog
+      motionPreset="slideInBottom"
+      leastDestructiveRef={cancelRef}
+      onClose={() => setIsOpen(false)}
+      isOpen={isOpen}
+      isCentered>
+      <AlertDialogOverlay />
+
+      <AlertDialogContent>
+        <AlertDialogHeader>Confirm navigation</AlertDialogHeader>
+        <AlertDialogCloseButton />
+        <AlertDialogBody>
+          {text ?? "You have unsaved changes , are you sure you want to leave?"}
+        </AlertDialogBody>
+        <AlertDialogFooter>
+          <Button colorScheme="blue" ref={cancelRef} onClick={() => setIsOpen(false)}>
+            Stay
+          </Button>
+          <Button
+            colorScheme="red"
+            ml={3}
+            onClick={() => {
+              setUnsavedChanges(false);
+              setIsOpen(false);
+              onClick();
+            }}>
+            Leave
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+export default UnsavedChangesAlert;

--- a/frontend/src/components/Forms/Action/ActionForm.tsx
+++ b/frontend/src/components/Forms/Action/ActionForm.tsx
@@ -10,8 +10,10 @@ import {
   Textarea,
   Wrap
 } from "@chakra-ui/react";
+import { UnsavedChangesContext } from "contexts/UnsavedChangesContext";
 import { useLocales } from "hooks/useLocales";
-import React, { FC, useCallback, useEffect, useState } from "react";
+import { useUnsavedAlert } from "hooks/useUnsavedAlert";
+import React, { FC, useCallback, useContext, useEffect, useState } from "react";
 import { ActionDto, IActionDto } from "services/backend/nswagts";
 import { convertToIdentifier } from "utils/convertTitleToIdentifier";
 
@@ -26,11 +28,13 @@ const ActionForm: FC<Props> = ({ submitCallback }) => {
   const [adminNote, setAdminNote] = useState("");
   const [identifier, setIdentifier] = useState("");
   const { t } = useLocales();
+  const { setUnsavedChanges } = useUnsavedAlert();
 
   const onSubmit = useCallback(
     async event => {
       setIsLoading(true);
       event.preventDefault();
+      setUnsavedChanges(false);
       await submitCallback(
         new ActionDto({
           title: title,
@@ -48,8 +52,13 @@ const ActionForm: FC<Props> = ({ submitCallback }) => {
     if (title) {
       const timeOutId = setTimeout(() => setIdentifier(convertToIdentifier(title)), 700);
       return () => clearTimeout(timeOutId);
-    }
+    } else setIdentifier("");
   }, [title]);
+
+  useEffect(() => {
+    if (title || description || adminNote) setUnsavedChanges(true);
+    else setUnsavedChanges(false);
+  }, [title, description, adminNote]);
 
   return (
     <Center>

--- a/frontend/src/components/Forms/Action/ActionForm.tsx
+++ b/frontend/src/components/Forms/Action/ActionForm.tsx
@@ -10,10 +10,9 @@ import {
   Textarea,
   Wrap
 } from "@chakra-ui/react";
-import { UnsavedChangesContext } from "contexts/UnsavedChangesContext";
 import { useLocales } from "hooks/useLocales";
 import { useUnsavedAlert } from "hooks/useUnsavedAlert";
-import React, { FC, useCallback, useContext, useEffect, useState } from "react";
+import React, { FC, useCallback, useEffect, useState } from "react";
 import { ActionDto, IActionDto } from "services/backend/nswagts";
 import { convertToIdentifier } from "utils/convertTitleToIdentifier";
 

--- a/frontend/src/components/Forms/Application/AppTokenForm.tsx
+++ b/frontend/src/components/Forms/Application/AppTokenForm.tsx
@@ -10,8 +10,9 @@ import {
   Textarea,
   Wrap
 } from "@chakra-ui/react";
+import { UnsavedChangesContext } from "contexts/UnsavedChangesContext";
 import { useLocales } from "hooks/useLocales";
-import React, { FC, useCallback, useEffect, useState } from "react";
+import React, { FC, useCallback, useContext, useEffect, useState } from "react";
 import { AppTokenCreateDto, IAppTokenCreateDto } from "services/backend/nswagts";
 import { convertToIdentifier } from "utils/convertTitleToIdentifier";
 
@@ -25,11 +26,13 @@ const AppTokenForm: FC<Props> = ({ submitCallback }) => {
   const [identifier, setIdentifier] = useState("");
   const [title, setTitle] = useState("");
   const { t } = useLocales();
+  const { setUnsavedChanges } = useContext(UnsavedChangesContext);
 
   const handleSubmit = useCallback(
     async event => {
       event.preventDefault();
       setIsLoading(true);
+      setUnsavedChanges(false);
       await submitCallback(
         new AppTokenCreateDto({ tokenIdentifier: identifier, description: description })
       );
@@ -44,6 +47,12 @@ const AppTokenForm: FC<Props> = ({ submitCallback }) => {
       return () => clearTimeout(timeOutId);
     } else setIdentifier("");
   }, [title]);
+
+  useEffect(() => {
+    if (title || description) {
+      setUnsavedChanges(true);
+    } else setUnsavedChanges(false);
+  }, [title, description]);
 
   return (
     <Center>

--- a/frontend/src/components/Forms/ReviewAcces/ReviewTokenForm.tsx
+++ b/frontend/src/components/Forms/ReviewAcces/ReviewTokenForm.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Center, Heading, useToast, VStack } from "@chakra-ui/react";
 import { ServiceViewContext } from "contexts/ServiceViewContext";
 import { useLocales } from "hooks/useLocales";
+import { useUnsavedAlert } from "hooks/useUnsavedAlert";
 import React, { FC, useCallback, useContext, useState } from "react";
 import { genApplicationClient } from "services/backend/apiClients";
 import {
@@ -21,6 +22,7 @@ const ReviewTokenForm: FC<Props> = ({ token }) => {
   const [isLoading, setIsLoading] = useState(false);
   const toast = useToast();
   const { t } = useLocales();
+  const { setUnsavedChanges } = useUnsavedAlert();
   const [actions, setActions] = useState<AppTokenActionUpdateDto[]>(() =>
     token.appTokenActions.map(
       action =>
@@ -46,6 +48,7 @@ const ReviewTokenForm: FC<Props> = ({ token }) => {
             })
           })
         );
+        setUnsavedChanges(false);
         toast({
           description: t("toasts.submitted"),
           status: "success",
@@ -68,6 +71,7 @@ const ReviewTokenForm: FC<Props> = ({ token }) => {
 
   const updateAction = useCallback(
     (index: number, action: AppTokenActionUpdateDto) => {
+      setUnsavedChanges(true);
       setActions(
         actions.map(x => {
           if (actions.indexOf(x) == index) x == action;

--- a/frontend/src/components/Forms/ReviewAcces/ReviewTokenModalTrigger.tsx
+++ b/frontend/src/components/Forms/ReviewAcces/ReviewTokenModalTrigger.tsx
@@ -10,8 +10,10 @@ import {
   ModalOverlay,
   useDisclosure
 } from "@chakra-ui/react";
+import UnsavedChangesAlert from "components/Common/UnsavedChangesAlert";
 import ReviewTokenForm from "components/Forms/ReviewAcces/ReviewTokenForm";
 import { useLocales } from "hooks/useLocales";
+import { useUnsavedAlert } from "hooks/useUnsavedAlert";
 import React, { FC } from "react";
 import { AppTokenIdDto } from "services/backend/nswagts";
 
@@ -22,6 +24,7 @@ type Props = {
 const ReviewTokenModalTrigger: FC<Props> = ({ token }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { t } = useLocales();
+  const { alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
 
   return (
     <>
@@ -29,7 +32,15 @@ const ReviewTokenModalTrigger: FC<Props> = ({ token }) => {
         {t("serviceScreen.pendingTokens.reviewToken")}
       </Button>
 
-      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside" size="4xl">
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          if (unsavedChanged) {
+            setAlertOpen(true);
+          } else onClose();
+        }}
+        scrollBehavior="inside"
+        size="4xl">
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>
@@ -40,11 +51,25 @@ const ReviewTokenModalTrigger: FC<Props> = ({ token }) => {
           <ModalCloseButton />
           <Divider />
           <ModalBody>
+            <UnsavedChangesAlert
+              isOpen={alertOpen}
+              setIsOpen={setAlertOpen}
+              onClick={() => {
+                onClose();
+              }}
+            />
             <ReviewTokenForm token={token} />
           </ModalBody>
           <Divider />
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
+            <Button
+              colorScheme="blue"
+              mr={3}
+              onClick={() => {
+                if (unsavedChanged) {
+                  setAlertOpen(true);
+                } else onClose();
+              }}>
               {t("commonButtons.close")}
             </Button>
           </ModalFooter>

--- a/frontend/src/components/GoogleUserSearch/GoogleSearchBar.tsx
+++ b/frontend/src/components/GoogleUserSearch/GoogleSearchBar.tsx
@@ -6,8 +6,9 @@ import { Box, Flex } from "@chakra-ui/layout";
 import { Popover, PopoverBody, PopoverContent } from "@chakra-ui/popover";
 import { Tag } from "@chakra-ui/tag";
 import { BsX } from "@react-icons/all-files/bs/BsX";
+import { UnsavedChangesContext } from "contexts/UnsavedChangesContext";
 import { useLocales } from "hooks/useLocales";
-import React, { FC, useCallback, useEffect, useReducer, useState } from "react";
+import React, { FC, useCallback, useContext, useEffect, useReducer, useState } from "react";
 import ListReducer, { ListReducerActionType } from "react-list-reducer";
 import { genGoogleUserClient } from "services/backend/apiClients";
 import { IUser } from "services/backend/nswagts";
@@ -25,6 +26,7 @@ const GoogleSearchBar: FC<Props> = ({ submitUsers }) => {
   const [filteredUsers, setFilteredUsers] = useState<IUser[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const { t } = useLocales();
+  const { setUnsavedChanges } = useContext(UnsavedChangesContext);
 
   const fetchGoogleUsers = useCallback(async () => {
     try {
@@ -48,6 +50,9 @@ const GoogleSearchBar: FC<Props> = ({ submitUsers }) => {
   // Tells parent component that the local userList has been changed
   useEffect(() => {
     submitUsers(addedUsers);
+
+    if (addedUsers.length > 0) setUnsavedChanges(true);
+    else setUnsavedChanges(false);
   }, [addedUsers]);
 
   const addUser = useCallback(

--- a/frontend/src/components/ServiceScreen/Actions/ActionApprovers/AddActionApproverTriggerBtn.tsx
+++ b/frontend/src/components/ServiceScreen/Actions/ActionApprovers/AddActionApproverTriggerBtn.tsx
@@ -11,9 +11,11 @@ import {
   useDisclosure
 } from "@chakra-ui/react";
 import PopoverMenuButton from "components/Common/PopoverMenuButton";
+import UnsavedChangesAlert from "components/Common/UnsavedChangesAlert";
 import ActionApproverForm from "components/Forms/Service/ActionApproverForm";
 import { ServiceViewContext } from "contexts/ServiceViewContext";
 import { useLocales } from "hooks/useLocales";
+import { useUnsavedAlert } from "hooks/useUnsavedAlert";
 import React, { FC, useCallback, useContext } from "react";
 import { IActionApproverDto } from "services/backend/nswagts";
 
@@ -24,8 +26,10 @@ const AddActionApproverTriggerBtn: FC<Props> = ({ submitCallback }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { currAction } = useContext(ServiceViewContext);
   const { t } = useLocales();
+  const { setUnsavedChanges, alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
 
   const handleSubmit = useCallback(async (OwnerMetaDataForm: IActionApproverDto[]) => {
+    setUnsavedChanges(false);
     submitCallback(currAction.id, OwnerMetaDataForm);
   }, []);
 
@@ -33,7 +37,15 @@ const AddActionApproverTriggerBtn: FC<Props> = ({ submitCallback }) => {
     <>
       <PopoverMenuButton btnText={t("serviceScreen.actions.addApprovers")} onClickMethod={onOpen} />
 
-      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside" size="3xl">
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          if (unsavedChanged) {
+            setAlertOpen(true);
+          } else onClose();
+        }}
+        scrollBehavior="inside"
+        size="3xl">
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>
@@ -42,11 +54,25 @@ const AddActionApproverTriggerBtn: FC<Props> = ({ submitCallback }) => {
           <ModalCloseButton />
           <Divider />
           <ModalBody>
+            <UnsavedChangesAlert
+              isOpen={alertOpen}
+              setIsOpen={setAlertOpen}
+              onClick={() => {
+                onClose();
+              }}
+            />
             <ActionApproverForm submitCallback={handleSubmit} />
           </ModalBody>
           <Divider />
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
+            <Button
+              colorScheme="blue"
+              mr={3}
+              onClick={() => {
+                if (unsavedChanged) {
+                  setAlertOpen(true);
+                } else onClose();
+              }}>
               {t("commonButtons.close")}
             </Button>
           </ModalFooter>

--- a/frontend/src/components/ServiceScreen/Actions/ActionApprovers/CopyApprovers/CopyActionsList.tsx
+++ b/frontend/src/components/ServiceScreen/Actions/ActionApprovers/CopyApprovers/CopyActionsList.tsx
@@ -1,6 +1,7 @@
 import { Button, Checkbox, Table, Tbody, Th, Thead, Tr, VStack } from "@chakra-ui/react";
+import { UnsavedChangesContext } from "contexts/UnsavedChangesContext";
 import { useLocales } from "hooks/useLocales";
-import React, { FC, useCallback, useState } from "react";
+import React, { FC, useCallback, useContext, useEffect, useState } from "react";
 import { ActionIdDto, IActionIdDto } from "services/backend/nswagts";
 
 import CopyActionListItem from "./CopyActionListItem";
@@ -20,6 +21,12 @@ const CopyActionList: FC<Props> = ({ tableData, submitCallback }) => {
       checked: false
     }))
   );
+  const { setUnsavedChanges } = useContext(UnsavedChangesContext);
+
+  useEffect(() => {
+    if (checkboxes.find(e => e.checked == true)) setUnsavedChanges(true);
+    else setUnsavedChanges(false);
+  }, [checkboxes]);
 
   const checkAll = useCallback(() => {
     setCheckboxes(
@@ -53,6 +60,7 @@ const CopyActionList: FC<Props> = ({ tableData, submitCallback }) => {
         approvers.push(modal.id);
       }
     });
+    setUnsavedChanges(false);
     await submitCallback(approvers);
     setIsLoading(false);
   }, [checkboxes]);

--- a/frontend/src/components/ServiceScreen/Actions/ActionApprovers/CopyApprovers/CopyApproversTriggerBtn.tsx
+++ b/frontend/src/components/ServiceScreen/Actions/ActionApprovers/CopyApprovers/CopyApproversTriggerBtn.tsx
@@ -12,8 +12,10 @@ import {
   useDisclosure
 } from "@chakra-ui/react";
 import PopoverMenuButton from "components/Common/PopoverMenuButton";
+import UnsavedChangesAlert from "components/Common/UnsavedChangesAlert";
 import { ServiceViewContext } from "contexts/ServiceViewContext";
 import { useLocales } from "hooks/useLocales";
+import { useUnsavedAlert } from "hooks/useUnsavedAlert";
 import React, { FC, useCallback, useContext } from "react";
 import { IActionApproverDto } from "services/backend/nswagts";
 
@@ -28,6 +30,8 @@ const CopyApproverTriggerBtn: FC<Props> = ({ approversToCopy, submitCallback }) 
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { currService, currAction } = useContext(ServiceViewContext);
   const { t } = useLocales();
+  const { setUnsavedChanges, alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
+
   const handleSubmit = useCallback(
     async (actionIds: number[]) => {
       actionIds.forEach(async actionId => {
@@ -45,7 +49,15 @@ const CopyApproverTriggerBtn: FC<Props> = ({ approversToCopy, submitCallback }) 
         onClickMethod={onOpen}
       />
 
-      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside" size="5xl">
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          if (unsavedChanged) {
+            setAlertOpen(true);
+          } else onClose();
+        }}
+        scrollBehavior="inside"
+        size="5xl">
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>
@@ -54,6 +66,13 @@ const CopyApproverTriggerBtn: FC<Props> = ({ approversToCopy, submitCallback }) 
           <ModalCloseButton />
           <Divider />
           <ModalBody>
+            <UnsavedChangesAlert
+              isOpen={alertOpen}
+              setIsOpen={setAlertOpen}
+              onClick={() => {
+                onClose();
+              }}
+            />
             <ActionApproverOverview approvers={approversToCopy} />
             <Box p="3">
               <CopyActionList
@@ -64,7 +83,14 @@ const CopyApproverTriggerBtn: FC<Props> = ({ approversToCopy, submitCallback }) 
           </ModalBody>
           <Divider />
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
+            <Button
+              colorScheme="blue"
+              mr={3}
+              onClick={() => {
+                if (unsavedChanged) {
+                  setAlertOpen(true);
+                } else onClose();
+              }}>
               {t("commonButtons.close")}
             </Button>
           </ModalFooter>

--- a/frontend/src/components/ServiceScreen/Actions/ActionApprovers/CopyApprovers/CopyApproversTriggerBtn.tsx
+++ b/frontend/src/components/ServiceScreen/Actions/ActionApprovers/CopyApprovers/CopyApproversTriggerBtn.tsx
@@ -30,7 +30,7 @@ const CopyApproverTriggerBtn: FC<Props> = ({ approversToCopy, submitCallback }) 
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { currService, currAction } = useContext(ServiceViewContext);
   const { t } = useLocales();
-  const { setUnsavedChanges, alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
+  const { alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
 
   const handleSubmit = useCallback(
     async (actionIds: number[]) => {
@@ -48,7 +48,6 @@ const CopyApproverTriggerBtn: FC<Props> = ({ approversToCopy, submitCallback }) 
         btnText={t("serviceScreen.actions.copyApproversToAnotherAction")}
         onClickMethod={onOpen}
       />
-
       <Modal
         isOpen={isOpen}
         onClose={() => {

--- a/frontend/src/components/ServiceScreen/Actions/CreateActionTriggerBtn.tsx
+++ b/frontend/src/components/ServiceScreen/Actions/CreateActionTriggerBtn.tsx
@@ -12,9 +12,11 @@ import {
   useToast
 } from "@chakra-ui/react";
 import { BsPlus } from "@react-icons/all-files/bs/BsPlus";
+import UnsavedChangesAlert from "components/Common/UnsavedChangesAlert";
 import ActionForm from "components/Forms/Action/ActionForm";
 import { ServiceViewContext } from "contexts/ServiceViewContext";
 import { useLocales } from "hooks/useLocales";
+import { useUnsavedAlert } from "hooks/useUnsavedAlert";
 import React, { FC, useCallback, useContext } from "react";
 import { genServiceClient } from "services/backend/apiClients";
 import { ActionDto, CreateActionCommand } from "services/backend/nswagts";
@@ -25,6 +27,7 @@ const CreateActionTriggerBtn: FC = () => {
   const { currService, setNewCurrService } = useContext(ServiceViewContext);
   const { t } = useLocales();
   const toast = useToast();
+  const { alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
 
   const createAction = useCallback(
     async (metaData: ActionDto) => {
@@ -59,6 +62,7 @@ const CreateActionTriggerBtn: FC = () => {
         });
       } finally {
         setNewCurrService(currService.id);
+        onClose();
       }
     },
     [currService]
@@ -71,18 +75,40 @@ const CreateActionTriggerBtn: FC = () => {
         {t("serviceScreen.buttons.createNewAction")}
       </Button>
 
-      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside" size="5xl">
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          if (unsavedChanged) {
+            setAlertOpen(true);
+          } else onClose();
+        }}
+        scrollBehavior="inside"
+        size="5xl">
         <ModalOverlay />
         <ModalContent>
           <ModalHeader> {t("serviceScreen.modalHeaders.addAction")}</ModalHeader>
           <ModalCloseButton />
           <Divider />
           <ModalBody>
+            <UnsavedChangesAlert
+              isOpen={alertOpen}
+              setIsOpen={setAlertOpen}
+              onClick={() => {
+                onClose();
+              }}
+            />
             <ActionForm submitCallback={createAction} />
           </ModalBody>
           <Divider />
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
+            <Button
+              colorScheme="blue"
+              mr={3}
+              onClick={() => {
+                if (unsavedChanged) {
+                  setAlertOpen(true);
+                } else onClose();
+              }}>
               {t("commonButtons.close")}
             </Button>
           </ModalFooter>

--- a/frontend/src/components/ServiceScreen/Owners/AddServiceOwnerTriggerBtn.tsx
+++ b/frontend/src/components/ServiceScreen/Owners/AddServiceOwnerTriggerBtn.tsx
@@ -12,9 +12,11 @@ import {
   useToast
 } from "@chakra-ui/react";
 import { BsPlus } from "@react-icons/all-files/bs/BsPlus";
+import UnsavedChangesAlert from "components/Common/UnsavedChangesAlert";
 import ServiceOwnerForm from "components/Forms/Service/ServiceOwnerForm";
 import { ServiceViewContext } from "contexts/ServiceViewContext";
 import { useLocales } from "hooks/useLocales";
+import { useUnsavedAlert } from "hooks/useUnsavedAlert";
 import React, { FC, useCallback, useContext } from "react";
 import { genServiceClient } from "services/backend/apiClients";
 import { CreateServiceOwnerCommand, ServiceOwnerDto } from "services/backend/nswagts";
@@ -24,6 +26,7 @@ const AddServiceOwnersTriggerBtn: FC = () => {
   const { fetchOwners, currService } = useContext(ServiceViewContext);
   const { t } = useLocales();
   const toast = useToast();
+  const { setUnsavedChanges, alertOpen, setAlertOpen, unsavedChanged } = useUnsavedAlert();
 
   const addOwners = useCallback(
     async (form: ServiceOwnerDto[]) => {
@@ -35,6 +38,7 @@ const AddServiceOwnersTriggerBtn: FC = () => {
             serviceOwners: form
           })
         );
+        setUnsavedChanges(false);
         toast({
           description: t("toasts.xAdded", { x: t("entityNames.plural.owners") }),
           status: "success",
@@ -64,7 +68,15 @@ const AddServiceOwnersTriggerBtn: FC = () => {
         {t("serviceScreen.buttons.addOwners")}
       </Button>
 
-      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside" size="5xl">
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          if (unsavedChanged) {
+            setAlertOpen(true);
+          } else onClose();
+        }}
+        scrollBehavior="inside"
+        size="5xl">
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>
@@ -75,11 +87,23 @@ const AddServiceOwnersTriggerBtn: FC = () => {
           <ModalCloseButton />
           <Divider />
           <ModalBody>
+            <UnsavedChangesAlert
+              isOpen={alertOpen}
+              setIsOpen={setAlertOpen}
+              onClick={() => onclose}
+            />
             <ServiceOwnerForm submitCallback={addOwners} />
           </ModalBody>
           <Divider />
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
+            <Button
+              colorScheme="blue"
+              mr={3}
+              onClick={() => {
+                if (unsavedChanged) {
+                  setAlertOpen(true);
+                } else onClose();
+              }}>
               {t("commonButtons.close")}
             </Button>
           </ModalFooter>

--- a/frontend/src/components/ServiceScreen/Owners/AddServiceOwnerTriggerBtn.tsx
+++ b/frontend/src/components/ServiceScreen/Owners/AddServiceOwnerTriggerBtn.tsx
@@ -62,6 +62,10 @@ const AddServiceOwnersTriggerBtn: FC = () => {
     [currService, fetchOwners]
   );
 
+  const closeMe = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
   return (
     <>
       <Button onClick={onOpen} rightIcon={<BsPlus />} colorScheme="green">
@@ -87,11 +91,7 @@ const AddServiceOwnersTriggerBtn: FC = () => {
           <ModalCloseButton />
           <Divider />
           <ModalBody>
-            <UnsavedChangesAlert
-              isOpen={alertOpen}
-              setIsOpen={setAlertOpen}
-              onClick={() => onclose}
-            />
+            <UnsavedChangesAlert isOpen={alertOpen} setIsOpen={setAlertOpen} onClick={closeMe} />
             <ServiceOwnerForm submitCallback={addOwners} />
           </ModalBody>
           <Divider />

--- a/frontend/src/components/ServiceScreen/Owners/AddServiceOwnerTriggerBtn.tsx
+++ b/frontend/src/components/ServiceScreen/Owners/AddServiceOwnerTriggerBtn.tsx
@@ -62,10 +62,6 @@ const AddServiceOwnersTriggerBtn: FC = () => {
     [currService, fetchOwners]
   );
 
-  const closeMe = useCallback(() => {
-    onClose();
-  }, [onClose]);
-
   return (
     <>
       <Button onClick={onOpen} rightIcon={<BsPlus />} colorScheme="green">
@@ -91,7 +87,13 @@ const AddServiceOwnersTriggerBtn: FC = () => {
           <ModalCloseButton />
           <Divider />
           <ModalBody>
-            <UnsavedChangesAlert isOpen={alertOpen} setIsOpen={setAlertOpen} onClick={closeMe} />
+            <UnsavedChangesAlert
+              isOpen={alertOpen}
+              setIsOpen={setAlertOpen}
+              onClick={() => {
+                onClose();
+              }}
+            />
             <ServiceOwnerForm submitCallback={addOwners} />
           </ModalBody>
           <Divider />

--- a/frontend/src/contexts/UnsavedChangesContext.ts
+++ b/frontend/src/contexts/UnsavedChangesContext.ts
@@ -5,5 +5,9 @@ type ContextType = ReturnType<typeof useProtectChanges>;
 
 export const UnsavedChangesContext = createContext<ContextType>({
   unsavedChanged: false,
-  setUnsavedChanges: () => null
+  setUnsavedChanges: () => null,
+  alertOpen: false,
+  setAlertOpen: () => null,
+  targetUrl: null,
+  setTargetUrl: () => null
 });

--- a/frontend/src/hooks/useProtectChanges.ts
+++ b/frontend/src/hooks/useProtectChanges.ts
@@ -1,15 +1,47 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const useProtectChanges = () => {
   const [unsavedChanged, setUnsavedChanges] = useState(false);
+  const [alertOpen, setAlertOpen] = useState(false);
+  const [targetUrl, setTargetUrl] = useState<string>("");
   const router = useRouter();
 
-  useEffect(() => {
-    router.events.on("", () => {
-      // TODO protect the navigation by presenting a modal.
-    });
-  }, [router, unsavedChanged]);
+  const confirmationMessage = "Changes you made may not be saved. las";
+  const beforeUnloadHandler = (e: BeforeUnloadEvent) => {
+    (e || window.event).returnValue = confirmationMessage;
+    console.log(e);
+    console.log(window.event);
+    return confirmationMessage; // Gecko + Webkit, Safari, Chrome etc.
+  };
+  const beforeRouteHandler = (url: string) => {
+    if (router.pathname !== url) {
+      console.log(router.pathname);
+      console.log(url);
+      setTargetUrl(url);
+      setAlertOpen(true);
+      // to inform NProgress or something ...
+      router.events.emit("routeChangeError");
+      // tslint:disable-next-line: no-string-throw
+      throw `Route change to "${url}" was aborted (this error can be safely ignored). See https://github.com/zeit/next.js/issues/2476.`;
+    }
+  };
 
-  return { unsavedChanged, setUnsavedChanges };
+  useEffect(() => {
+    console.log("UnsavedChanges: " + unsavedChanged);
+    if (unsavedChanged) {
+      window.addEventListener("beforeunload", beforeUnloadHandler);
+      router.events.on("routeChangeStart", beforeRouteHandler);
+    } else {
+      window.removeEventListener("beforeunload", beforeUnloadHandler);
+      router.events.off("routeChangeStart", beforeRouteHandler);
+    }
+    return () => {
+      window.removeEventListener("beforeunload", beforeUnloadHandler);
+      router.events.off("routeChangeStart", beforeRouteHandler);
+    };
+  }, [unsavedChanged, setUnsavedChanges]);
+
+  return { unsavedChanged, setUnsavedChanges, alertOpen, setAlertOpen, targetUrl, setTargetUrl };
 };

--- a/frontend/src/hooks/useUnsavedAlert.ts
+++ b/frontend/src/hooks/useUnsavedAlert.ts
@@ -1,0 +1,16 @@
+import { UnsavedChangesContext } from "contexts/UnsavedChangesContext";
+import { useContext, useState } from "react";
+
+// ignore due to implied typing is better suited for this kind of hook
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const useUnsavedAlert = () => {
+  const [alertOpen, setAlertOpen] = useState(false);
+  const { setUnsavedChanges, unsavedChanged } = useContext(UnsavedChangesContext);
+
+  return {
+    alertOpen,
+    setAlertOpen,
+    setUnsavedChanges,
+    unsavedChanged
+  };
+};

--- a/frontend/src/i18n/Locale.ts
+++ b/frontend/src/i18n/Locale.ts
@@ -111,6 +111,7 @@ export interface Locale {
         appSecretWarningBar: string;
         appSecretWarning: string;
         generateSecret: string;
+        haveYouSavedAppSecret: string;
       };
     };
   };

--- a/frontend/src/i18n/da-DK.ts
+++ b/frontend/src/i18n/da-DK.ts
@@ -147,7 +147,9 @@ export const table: Locale = {
         og derfra JWT's`,
         appSecretWarning: `Dette kan kun gøres en gang og du er selv ansvarlig for at holde din secret sikker og hemmelig.
         Du bruger AppSecret'en til at signere dine tokens for derefter at få genereret en JWT`,
-        generateSecret: "Generer AppSecret"
+        generateSecret: "Generer AppSecret",
+        haveYouSavedAppSecret: `Er du sikker på at du har gemt din AppSecret korrekt og sikkert.
+        Den kan ikke generes igen senere, og uden den kan du ikke genere nye JWT's`
       }
     }
   },

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -110,29 +110,29 @@ export const table: Locale = {
         details: "Details"
       },
       infoBoxes: {
-        createTokenInfo: `(Danish)Here you can create a AppToken for your application. AppTokens are used to define a scope of services that your
+        createTokenInfo: `Here you can create a AppToken for your application. AppTokens are used to define a scope of services that your
         application wants to use. To create a AppToken you must first write a name that needs to be unique for the given application.
         The name will be converted into a identifier string which will be used throughout the application. Next you must write a 
         description of your tokens scope. Here you should describe what actions you are going to need as well as to what purpose.`,
-        BrowseTokenInfo: `(DANISH)This is the service library where you can see all the available services and their actions.
+        BrowseTokenInfo: `This is the service library where you can see all the available services and their actions.
         Use the search bar to filter the library based on service titles. To request and view further details about a service
         click their respective card. Here you can scroll through the service description to read about what each action does and how
         it is used, and finally at the end you can put checks next to the actions you want to request.
         After you've requested your actions there will be a button at the bottom of the screen which will submit your token for review.
         The respective service owners will then be able to review your request. You can follow the process on the next page
         or from the token table on the Application Screen.`,
-        SeeTokenStatusInfo: `(DANISH)Here you can see what actions your token contains as well as their current status. Next to each actions is a symbol showing if
+        SeeTokenStatusInfo: `Here you can see what actions your token contains as well as their current status. Next to each actions is a symbol showing if
         your request has been approved, rejected or still pending for review. Mouse over rejected actions to see the rejection reason.
         If all your actions have been approved you can generate your JWT. The JWT is based on your unique Application identifier and your
         unique token identifier and its approved service actions. Finally you will also need to input your App Secret in order to sign the JWT.`,
-        GenerateJwtInfo: `(DANISH)Here you can generate your JWT if you have your AppSecret at hand. Your AppSecret is a special
+        GenerateJwtInfo: `Here you can generate your JWT if you have your AppSecret at hand. Your AppSecret is a special
         string that only can be fetched once. Mostly the AppSecret is generated shortly after your application has been made.
         If you don't have your AppSecret try and check with your fellow ApplicationOwners to see if perhaps they've already generated it. If you've lost 
         your AppSecret you need to create a Application from scratch and go through the Create Token progress again. The generated JWT can
         then be used in your application to verify that you have access to the requested services and actions.`
       },
       appSecret: {
-        appSecretPlaceholder: "Du fik denne da du oprettede applikationen",
+        appSecretPlaceholder: "You got this when you created your application",
         appSecretWarningBar: `You have not generated your AppSecret for this Application.
          This is required to generate your AppTokens and JWT`,
         appSecretWarning: `This can only be done once and you are responsible for keeping it safe and secure. The

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -185,7 +185,7 @@ export const table: Locale = {
     submittedE: "Submission failed:",
     xCreated: `{{x}} created`,
     xCreatedE: "{{x}} was not created, error:",
-    xAdded: `{{x}} was not added`,
+    xAdded: `{{x}} was added`,
     xAddedE: "{{x}} was not added, error:",
     accessRequested: "Access was requested",
     accessRequestedE: "Access request failed:",

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -137,7 +137,9 @@ export const table: Locale = {
          This is required to generate your AppTokens and JWT`,
         appSecretWarning: `This can only be done once and you are responsible for keeping it safe and secure. The
         AppSecret is used for signing your AppTokens in order to generate a JWT.`,
-        generateSecret: "Generate AppSecret"
+        generateSecret: "Generate AppSecret",
+        haveYouSavedAppSecret: `Are you sure you have stored the AppSecret? This can't be retrieved
+        again later, and without it you can't generate new JWT's`
       }
     }
   },

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import "../styles.global.css";
 import "isomorphic-unfetch";
 
 import { Center, ChakraProvider, CircularProgress } from "@chakra-ui/react";
+import RouteAlertModal from "components/Common/RouteAlertModal";
 import { UnsavedChangesContext } from "contexts/UnsavedChangesContext";
 import { AuthStage, useAuth } from "hooks/useAuth";
 import { useProtectChanges } from "hooks/useProtectChanges";
@@ -77,6 +78,7 @@ const MyApp = ({ Component, pageProps, __N_SSG, router }: AppPropsType & Props):
         <I18nProvider table={pageProps.table}>
           <ChakraProvider theme={theme}>
             <UnsavedChangesContext.Provider value={protectChanges}>
+              <RouteAlertModal />
               {/* <AuthContext.Provider value={auth}> */}
               {/* <SignalRContext.Provider value={{ connection }}> */}
               <Component {...pageProps} />


### PR DESCRIPTION
Depends on #113 

Added 2 forms of protection of UnsavedChanges or Appsecret Generation. There is the global context which keeps track of unsavedChanges and of when to show alert Dialog. The alert triggers on URL changes, refresh and back button presses. This shows the default browser confirm dialog. My own custom alert only triggers on NEXT.js route changes.

Since most of the app navigation is through modals and drawers route.push is rarely called, therefore I also made a default component and hook that can be implemented easy on pages/forms that require it.

All forms now use this custom UnsavedChangedAlert.
UnsavedChanges also triggers when users generate their AppSecret as a last line of defense for users not saving it properly.